### PR TITLE
[REF] prettierrc.yml: Enable xmlSelfClosingSpace

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.prettierrc.yml
+++ b/src/pre_commit_vauxoo/cfg/.prettierrc.yml
@@ -5,4 +5,4 @@ proseWrap: always
 semi: true
 trailingComma: "es5"
 xmlWhitespaceSensitivity: "strict"
-xmlSelfClosingSpace: false
+xmlSelfClosingSpace: true


### PR DESCRIPTION
The "xmlSelfClosingSpace" parameter is a flag:
 - https://github.com/prettier/plugin-xml/blob/ae911c9d287f229df5f/src/plugin.ts#L16

It is not able to ignore it

It was disabled in order to avoid a big diff but for projects using the OCA standard
where this flag is enabled it is generating a big diff too

In order to stick to OCA configuration this flag is enabled