### PR TITLE
[REF] click: Remove incompatible parameter for all click versions

### DIFF
--- a/src/pre_commit_vauxoo/cli.py
+++ b/src/pre_commit_vauxoo/cli.py
@@ -82,7 +82,7 @@ def strcsv2tuple(strcsv, is_path=False):
 @click.option(
     "--config",
     "-c",
-    type=click.Choice(["mandatory", "optional", "fix", "all"], case_sensitive=False),
+    type=click.Choice(["mandatory", "optional", "fix", "all"]),
     default=["mandatory", "optional"],
     show_default=True,
     multiple=True,


### PR DESCRIPTION
Using click 6.6 shows the following traceback:

      File "pre_commit_vauxoo/cli.py", line 85, in <module>
        type=click.Choice(["mandatory", "optional", "fix", "all"], case_sensitive=False),
    TypeError: __init__() got an unexpected keyword argument 'case_sensitive'