### PR TITLE
[REF] pre_commit_vauxoo: Enable black's string normalization and add extra parameter to disable it

### DIFF
--- a/src/pre_commit_vauxoo/cfg/pyproject.toml
+++ b/src/pre_commit_vauxoo/cfg/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length=119
-skip-string-normalization=true
+skip-string-normalization=false

--- a/src/pre_commit_vauxoo/cli.py
+++ b/src/pre_commit_vauxoo/cli.py
@@ -239,6 +239,18 @@ PRECOMMIT_HOOKS_TYPE += ["all"] + ["-%s" % i for i in PRECOMMIT_HOOKS_TYPE]
     **new_extra_kwargs,
 )
 @click.option(
+    "--skip-string-normalization",
+    "-S",
+    envvar="BLACK_SKIP_STRING_NORMALIZATION",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="If '-t fix' is enabled, "
+    "don't normalize string quotes or prefixes '' -> \"\""
+    "\f\nThis parameter is related to 'black' hook",
+    **new_extra_kwargs,
+)
+@click.option(
     "--precommit-hooks-type",
     "-t",
     type=CSVChoice(PRECOMMIT_HOOKS_TYPE),

--- a/src/pre_commit_vauxoo/pre_commit_vauxoo.py
+++ b/src/pre_commit_vauxoo/pre_commit_vauxoo.py
@@ -30,7 +30,13 @@ def get_files(path):
 
 
 def copy_cfg_files(
-    precommit_config_dir, repo_dirname, no_overwrite, exclude_lint, pylint_disable_checks, exclude_autofix
+    precommit_config_dir,
+    repo_dirname,
+    no_overwrite,
+    exclude_lint,
+    pylint_disable_checks,
+    exclude_autofix,
+    skip_string_normalization,
 ):
     exclude_lint_regex = ""
     exclude_autofix_regex = ""
@@ -75,6 +81,8 @@ def copy_cfg_files(
                         "Disabling the following pylint checks (PYLINT_DISABLE_CHECKS): %s", pylint_disable_checks
                     )
                     line = line.replace("R0000", ",".join(pylint_disable_checks))
+                if fname == "pyproject.toml" and line.startswith("skip-string-normalization"):
+                    line = "skip-string-normalization=%s" % (skip_string_normalization and "true" or "false")
                 fdst.write(line)
 
 
@@ -117,6 +125,7 @@ def main(
     precommit_hooks_type,
     fail_optional,
     install,
+    skip_string_normalization,
     do_exit=True,
 ):
     repo_dirname = get_repo()
@@ -142,6 +151,7 @@ def main(
         exclude_lint,
         pylint_disable_checks,
         exclude_autofix,
+        skip_string_normalization,
     )
     _logger.info("Installing pre-commit hooks")
     cmd = ["pre-commit", "install-hooks", "--color=always"]

--- a/src/pre_commit_vauxoo/pre_commit_vauxoo.py
+++ b/src/pre_commit_vauxoo/pre_commit_vauxoo.py
@@ -134,8 +134,8 @@ def main(
     root_dir = os.path.abspath(os.path.dirname(__file__))
 
     if install:
-        git_hook_pre_commit_src = os.path.join(root_dir, 'git_hook_pre_commit')
-        git_hook_pre_commit_dest = os.path.join(repo_dirname, '.git', 'hooks', 'pre-commit')
+        git_hook_pre_commit_src = os.path.join(root_dir, "git_hook_pre_commit")
+        git_hook_pre_commit_dest = os.path.join(repo_dirname, ".git", "hooks", "pre-commit")
         _logger.info("pre-commit installed at %s", git_hook_pre_commit_dest)
         shutil.copy(git_hook_pre_commit_src, git_hook_pre_commit_dest)
         if do_exit:

--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -96,9 +96,9 @@ class TestPreCommitVauxoo(unittest.TestCase):
 
     def test_install_git_hook_pre_commit(self):
         """Test .git/hooks/pre-commit script"""
-        git_hook_pre_commit = os.path.join(self.tmp_dir, '.git', 'hooks', 'pre-commit')
+        git_hook_pre_commit = os.path.join(self.tmp_dir, ".git", "hooks", "pre-commit")
         self.assertFalse(os.path.isfile(git_hook_pre_commit), "File created before to install it")
-        result = self.runner.invoke(main, ['--install'])
+        result = self.runner.invoke(main, ["--install"])
         self.assertEqual(result.exit_code, 0, "Exited with error %s" % result)
         self.assertTrue(os.path.isfile(git_hook_pre_commit), "File not created")
         with open(git_hook_pre_commit, "r") as f_git_hook_pre_commit:

--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -30,8 +30,7 @@ class TestPreCommitVauxoo(unittest.TestCase):
     def tearDown(self):
         super().tearDown()
         # change to original work dir
-        if os.path.isdir(self.original_work_dir):
-            os.chdir(self.original_work_dir)
+        os.chdir(self.original_work_dir)
         # Cleanup temporary files
         if os.path.isdir(self.tmp_dir) and self.tmp_dir != "/":
             shutil.rmtree(self.tmp_dir, ignore_errors=True)
@@ -44,6 +43,8 @@ class TestPreCommitVauxoo(unittest.TestCase):
         os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"
         result = self.runner.invoke(main, [])
         self.assertEqual(result.exit_code, 0, "Exited with error %s" % result)
+        with open(os.path.join(self.tmp_dir, "pyproject.toml"), "r") as f_pyproject:
+            self.assertIn("skip-string-normalization=false", f_pyproject, "Skip string normalization not set")
 
     def test_chdir(self):
         self.runner = CliRunner()
@@ -56,9 +57,12 @@ class TestPreCommitVauxoo(unittest.TestCase):
         self.runner = CliRunner()
         os.chdir("resources")
         os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"
+        os.environ["BLACK_SKIP_STRING_NORMALIZATION"] = "false"
         os.environ["EXCLUDE_LINT"] = "resources/module_example1/models"
         result = self.runner.invoke(main, [])
         self.assertEqual(result.exit_code, 0, "Exited with error %s" % result)
+        with open(os.path.join(self.tmp_dir, "pyproject.toml"), "r") as f_pyproject:
+            self.assertIn("skip-string-normalization=false", f_pyproject, "Skip string normalization not set")
 
     def test_disable_lints(self):
         self.runner = CliRunner()
@@ -71,8 +75,11 @@ class TestPreCommitVauxoo(unittest.TestCase):
         os.chdir("resources")
         os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"
         os.environ["EXCLUDE_AUTOFIX"] = "resources/module_example1/demo/"
+        os.environ["BLACK_SKIP_STRING_NORMALIZATION"] = "true"
         result = self.runner.invoke(main, [])
         self.assertEqual(result.exit_code, 0, "Exited with error %s" % result)
+        with open(os.path.join(self.tmp_dir, "pyproject.toml"), "r") as f_pyproject:
+            self.assertIn("skip-string-normalization=true", f_pyproject, "Skip string normalization not set")
 
     def test_fail_warning(self):
         os.environ["PRECOMMIT_FAIL_OPTIONAL"] = "1"


### PR DESCRIPTION
Add extra parameter to skip it

    --skip-string-normalization

And it is set as it in the black configuration file

String normalization is enabled by default now

So you will need to disable it manually where it is used if you don't like it