### PR TITLE
[REF] CI: Faster pypi publish, remove "needs" to run parallel but only trigger for stable branches and PRs and tags

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -230,14 +230,18 @@ jobs:
         python3 -m build --sdist --wheel --outdir dist_wo_pbr/ &&
         python3 -m build --no-isolation --sdist --wheel --outdir dist/ &&
         twine check dist/*
-    - name: TestPyPI publish package
-      if: runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover')
-      run: >-
-        python3 -m twine upload --verbose -u __token__ -p ${{ secrets.PYPI_TEST_API_TOKEN }} --repository-url https://test.pypi.org/legacy/ dist/* || true
+    # TODO: Publish package only for signed tags
     - name: Publish package
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover')
       run: >-
         python3 -m twine upload --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }} --repository-url https://upload.pypi.org/legacy/ dist/*
+    # TODO: Add GITHUB_RUN_ID.GITHUB_RUN_ATTEMPT.GITHUB_RUN_NUMBER to bumpversion to avoid duplicating upload versions or even the git sha
+    # For now, feel free to uncomment this line of code to test things related to upload to pypi (test)
+    # - name: TestPyPI publish package
+    #   if: runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover')
+    #   run: >-
+    #     python3 -m twine upload --verbose -u __token__ -p ${{ secrets.PYPI_TEST_API_TOKEN }} \
+    #       --repository-url https://test.pypi.org/legacy/ dist/* || true
     - name: codecov
       if: startsWith(matrix.tox_env, 'py')  # only coveralls in python tests
       uses: codecov/codecov-action@v3

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,5 +1,16 @@
 name: build
-on: [push, pull_request]
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+      - 'pypi*'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
 jobs:
   deployv:
     runs-on: ubuntu-latest
@@ -220,16 +231,13 @@ jobs:
         python3 -m build --no-isolation --sdist --wheel --outdir dist/ &&
         twine check dist/*
     - name: TestPyPI publish package
-      if: runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover') && startsWith(${{ secrets.PYPI_TEST_API_TOKEN }}, 'pypi')
+      if: runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover')
       run: >-
-        python3 -m twine upload --verbose -u moylop260 -p ${{ secrets.PYPI_TEST_API_TOKEN }} --repository-url https://test.pypi.org/legacy/ dist/*
-    - name: Check for unverified commits
-      uses: nadock/verified_commits_check@v1
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover')
+        python3 -m twine upload --verbose -u __token__ -p ${{ secrets.PYPI_TEST_API_TOKEN }} --repository-url https://test.pypi.org/legacy/ dist/* || true
     - name: Publish package
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover')
       run: >-
-        python3 -m twine upload --verbose -u moylop260 -p ${{ secrets.PYPI_API_TOKEN }} --repository-url https://upload.pypi.org/legacy/ dist/*
+        python3 -m twine upload --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }} --repository-url https://upload.pypi.org/legacy/ dist/*
     - name: codecov
       if: startsWith(matrix.tox_env, 'py')  # only coveralls in python tests
       uses: codecov/codecov-action@v3

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -214,22 +214,22 @@ jobs:
     - name: Build a binary wheel and a source tarball
       if: runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover')
       run: >-
-        python -m pip install build wheel twine && python -m
-        build
-        --sdist
-        --wheel
-        --outdir dist_wo_pbr/ && python -m
-        build
-        --no-isolation
-        --sdist
-        --wheel
-        --outdir dist/ &&
+        rm -rf dist_wo_pbr/ && rm -rf dist/ &&
+        python3 -m pip install build wheel twine &&
+        python3 -m build --sdist --wheel --outdir dist_wo_pbr/ &&
+        python3 -m build --no-isolation --sdist --wheel --outdir dist/ &&
         twine check dist/*
+    - name: TestPyPI publish package
+      if: runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover') && startsWith(${{ secrets.PYPI_TEST_API_TOKEN }}, 'pypi')
+      run: >-
+        python3 -m twine upload --verbose -u moylop260 -p ${{ secrets.PYPI_TEST_API_TOKEN }} --repository-url https://test.pypi.org/legacy/ dist/*
+    - name: Check for unverified commits
+      uses: nadock/verified_commits_check@v1
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover')
     - name: Publish package
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      run: >-
+        python3 -m twine upload --verbose -u moylop260 -p ${{ secrets.PYPI_API_TOKEN }} --repository-url https://upload.pypi.org/legacy/ dist/*
     - name: codecov
       if: startsWith(matrix.tox_env, 'py')  # only coveralls in python tests
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
The GH action to publish pypi `pypa/gh-action-pypi-publish@release/v1`

spends 0.5m building a docker image

but it could be released faster using directly `twine` and it is cached in pip

Only trigger GH actions for stable branch master and PRs to branch

and tags to auto-release to pypi

Even include pypi* branches in order to be able to test upload to pypi in stable


Continuation from https://github.com/Vauxoo/pre-commit-vauxoo/pull/42 but stable branch to test
