### PR TITLE
[FIX] pre_commit_vauxoo: Fix duplicate '-w' parameter

### DIFF
--- a/src/pre_commit_vauxoo/cli.py
+++ b/src/pre_commit_vauxoo/cli.py
@@ -186,11 +186,11 @@ PRECOMMIT_HOOKS_TYPE += ["all"] + ["-%s" % i for i in PRECOMMIT_HOOKS_TYPE]
     **new_extra_kwargs,
 )
 @click.option(
-    "--overwrite",
-    "-w",
-    envvar="PRECOMMIT_OVERWRITE_CONFIG_FILES",
+    "--no-overwrite",
+    envvar="PRECOMMIT_NO_OVERWRITE_CONFIG_FILES",
     type=click.BOOL,
-    default=True,
+    is_flag=True,
+    default=False,
     show_default=True,
     help="Overwrite configuration files. "
     "\f\n*If True, existing configuration files into the project will be overwritten. "
@@ -199,7 +199,6 @@ PRECOMMIT_HOOKS_TYPE += ["all"] + ["-%s" % i for i in PRECOMMIT_HOOKS_TYPE]
 )
 @click.option(
     "--fail-optional",
-    "-w",
     envvar="PRECOMMIT_FAIL_OPTIONAL",
     type=click.BOOL,
     default=False,

--- a/src/pre_commit_vauxoo/pre_commit_vauxoo.py
+++ b/src/pre_commit_vauxoo/pre_commit_vauxoo.py
@@ -29,7 +29,7 @@ def get_files(path):
 
 
 def copy_cfg_files(
-    precommit_config_dir, repo_dirname, overwrite, exclude_lint, pylint_disable_checks, exclude_autofix
+    precommit_config_dir, repo_dirname, no_overwrite, exclude_lint, pylint_disable_checks, exclude_autofix
 ):
     exclude_lint_regex = ""
     exclude_autofix_regex = ""
@@ -55,7 +55,7 @@ def copy_cfg_files(
             # if it is not a file skip
             continue
         dst = os.path.join(repo_dirname, fname)
-        if not overwrite and os.path.isfile(dst):
+        if no_overwrite and os.path.isfile(dst):
             # Use the custom files defined in the repo
             _logger.warning("Using custom file %s", dst)
             continue
@@ -109,7 +109,7 @@ def subprocess_call(command, *args, **kwargs):
 # pylint: disable=too-complex
 def main(
     paths,
-    overwrite,
+    no_overwrite,
     exclude_autofix,
     exclude_lint,
     pylint_disable_checks,
@@ -128,7 +128,7 @@ def main(
     copy_cfg_files(
         precommit_config_dir,
         repo_dirname,
-        overwrite,
+        no_overwrite,
         exclude_lint,
         pylint_disable_checks,
         exclude_autofix,


### PR DESCRIPTION
Invert the parameter to no-overwrite in order to use it as flag since it is false by default

and remove short name parameter for flags

Before this PR to avoid overwrite configuration files you needed using:
 - `--overwrite=false`

But it was `true` by default

After this PR you set `--no-overwrite` without value only to disable a default feature

