### PR TITLE
[REF] pre_commit_vauxoo: Deprecate PRECOMMIT_AUTOFIX in pro PRECOMMIT_HOOKS_TYPE=all

### DIFF
--- a/src/pre_commit_vauxoo/cli.py
+++ b/src/pre_commit_vauxoo/cli.py
@@ -239,17 +239,6 @@ PRECOMMIT_HOOKS_TYPE += ["all"] + ["-%s" % i for i in PRECOMMIT_HOOKS_TYPE]
     **new_extra_kwargs,
 )
 @click.option(
-    "--autofix",
-    "-f",
-    envvar="PRECOMMIT_AUTOFIX",
-    is_flag=True,
-    default=False,
-    show_default=True,
-    help="Run pre-commit with autofix configuration to change the source code."
-    "\f\nOverwrite '-t mandatory,optional,fix'",
-    **new_extra_kwargs,
-)
-@click.option(
     "--precommit-hooks-type",
     "-t",
     type=CSVChoice(PRECOMMIT_HOOKS_TYPE),

--- a/src/pre_commit_vauxoo/pre_commit_vauxoo.py
+++ b/src/pre_commit_vauxoo/pre_commit_vauxoo.py
@@ -113,7 +113,6 @@ def main(
     exclude_autofix,
     exclude_lint,
     pylint_disable_checks,
-    autofix,
     precommit_hooks_type,
     fail_optional,
     do_exit=True,
@@ -133,11 +132,6 @@ def main(
         pylint_disable_checks,
         exclude_autofix,
     )
-    if autofix:
-        precommit_hooks_type = ("mandatory", "optional", "fix")
-    elif not precommit_hooks_type:
-        precommit_hooks_type = ("mandatory", "optional")
-
     _logger.info("Installing pre-commit hooks")
     cmd = ["pre-commit", "install-hooks", "--color=always"]
     pre_commit_cfg_mandatory = os.path.join(repo_dirname, ".pre-commit-config.yaml")

--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -41,13 +41,13 @@ class TestPreCommitVauxoo(unittest.TestCase):
 
     def test_basic(self):
         os.environ["INCLUDE_LINT"] = "resources"
-        os.environ["PRECOMMIT_AUTOFIX"] = "1"
+        os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"
         result = self.runner.invoke(main, [])
         self.assertEqual(result.exit_code, 0, "Exited with error %s" % result)
 
     def test_chdir(self):
         self.runner = CliRunner()
-        os.environ["PRECOMMIT_AUTOFIX"] = "1"
+        os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"
         os.chdir("resources")
         result = self.runner.invoke(main, [])
         self.assertEqual(result.exit_code, 0, "Exited with error %s" % result)
@@ -55,7 +55,7 @@ class TestPreCommitVauxoo(unittest.TestCase):
     def test_exclude_lint_path(self):
         self.runner = CliRunner()
         os.chdir("resources")
-        os.environ["PRECOMMIT_AUTOFIX"] = "1"
+        os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"
         os.environ["EXCLUDE_LINT"] = "resources/module_example1/models"
         result = self.runner.invoke(main, [])
         self.assertEqual(result.exit_code, 0, "Exited with error %s" % result)
@@ -69,7 +69,7 @@ class TestPreCommitVauxoo(unittest.TestCase):
     def test_exclude_autofix(self):
         self.runner = CliRunner()
         os.chdir("resources")
-        os.environ["PRECOMMIT_AUTOFIX"] = "1"
+        os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"
         os.environ["EXCLUDE_AUTOFIX"] = "resources/module_example1/demo/"
         result = self.runner.invoke(main, [])
         self.assertEqual(result.exit_code, 0, "Exited with error %s" % result)


### PR DESCRIPTION
Prefer using precommit_hooks_type as help says

It is better to disable or enable many configuration files instead of confusing with a extra parameter to overwrite this parameter