### PR TITLE
[REF] CI: Trigger pipeline to dockerv if new release

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -248,8 +248,9 @@ jobs:
     # TODO: Publish package only for signed tags
     - name: Publish package
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover')
-      run: >-
+      run: |
         python3 -m twine upload --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }} --repository-url https://upload.pypi.org/legacy/ dist/*
+        curl -X POST -F token=${{ secrets.TRIGGER_TOKEN_DOCKERV }} -F ref=master https://git.vauxoo.com/api/v4/projects/443/trigger/pipeline
     # TODO: Add GITHUB_RUN_ID.GITHUB_RUN_ATTEMPT.GITHUB_RUN_NUMBER to bumpversion to avoid duplicating upload versions or even the git sha
     # For now, feel free to uncomment this line of code to test things related to upload to pypi (test)
     # - name: TestPyPI publish package


### PR DESCRIPTION
The environment variable was add from:
 - https://git.vauxoo.com/devops/vxci/-/settings/ci_cd - Section "Variables"

Literally, it is pressing the button to rebuild the last stable pipeline:
 - <img width="788" alt="Screen Shot 2022-09-12 at 17 17 18" src="https://user-images.githubusercontent.com/6644187/189769096-cf7a783f-08cc-43df-a4c1-c8c616568d49.png">

