### PR TITLE
[IMP] pre_commit_vauxoo: show diff with changes made in autofixes

### DIFF
--- a/src/pre_commit_vauxoo/pre_commit_vauxoo.py
+++ b/src/pre_commit_vauxoo/pre_commit_vauxoo.py
@@ -282,6 +282,8 @@ def main(
                     "4. Run `git commit ...` and `git push ...`\n",
                     msg_info,
                 )
+                diff_autofix = subprocess.check_output(["git", "diff"]).decode(sys.stdout.encoding).strip()[:2000]
+                _logger.info("Diff with changes:\n%s", diff_autofix)
             all_status[test_name]["level"] = logging.ERROR
             all_status[test_name]["status_msg"] = "Reformatted"
         else:


### PR DESCRIPTION
Sometimes the local environment is different to CI

e.g. python version

So, the auto-fixes could be different between CI and local environment

Currently, if locally is not reformatting but CI there is not an easy way to fix it

A hard way is to install the same python version or check what is different (e.g. pre-commit-vauxoo version, black version, cache and so on)

Could be great to show a diff with the changes in order to apply it locally only if the auto-fixes did changes from the CI

Close to the following section:

pre-commit-vauxoo/src/pre_commit_vauxoo/pre_commit_vauxoo.py](https://github.com/Vauxoo/pre-commit-vauxoo/blob/914148ae4c8a6bfba3246451612de8283471f4b3/src/pre_commit_vauxoo/pre_commit_vauxoo.py#L253

This MR show diff with changes made in autofixes.

Fix https://github.com/Vauxoo/pre-commit-vauxoo/issues/66


