### PR TITLE
[REF] cfg/.flake8: ignore E203 (whitespace before ':')

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.flake8
+++ b/src/pre_commit_vauxoo/cfg/.flake8
@@ -4,7 +4,9 @@
 # F999 pylint support this case with expected tests
 # W503 changed by W504 and OCA prefers allow both
 # F401 is legal in odoo __init__.py files
-ignore = E123,E133,E226,E241,E242,F811,F601,W503,W504
+# E203 (whitespace before ':') is handled by black and it doesn't consider black syntax like:
+# chunk = records[index : index + chunk_size]
+ignore = E123,E133,E203,E226,E241,E242,F811,F601,W503,W504
 max-line-length = 119
 per-file-ignores=
     __init__.py:F401


### PR DESCRIPTION
Because it's handled by black and it doesn't consider black syntax like:

    chunk = records[index : index + chunk_size]