### PR TITLE
[REF] pylintrc: Add 'column' to message-template option and change format

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pylintrc
+++ b/src/pre_commit_vauxoo/cfg/.pylintrc
@@ -372,7 +372,7 @@ disable=abstract-method,
 
 
 [REPORTS]
-msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+msg-template={path}:{line}:{column}: ({symbol}) {msg}
 # msg-template={module}:{line}: [{msg_id}({symbol})]
 output-format=colorized
 files-output=no

--- a/src/pre_commit_vauxoo/cfg/.pylintrc-optional
+++ b/src/pre_commit_vauxoo/cfg/.pylintrc-optional
@@ -92,7 +92,7 @@ enable=api-one-deprecated,
   xml-syntax-error,
 
 [REPORTS]
-msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+msg-template={path}:{line}:{column}: ({symbol}) {msg}
 output-format=colorized
 files-output=no
 reports=no


### PR DESCRIPTION
New way:
 - `test_account_move_out_refund.py:128:8: (super-with-arguments) Consider using Python 3 style super() without arguments`

Notice `128:8` where the number `8` is the column

The editors are able to open the file in the line and column where the check was raised

* The `msg-id` was removed since it is invalid to disable comments
* The `object` was removed in order to get a shorter message