### PR TITLE
[REF] tests: Remove git --initial-branch parameter incompatible with old git version

### DIFF
--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -28,7 +28,7 @@ class TestPreCommitVauxoo(unittest.TestCase):
 
     def create_dummy_repo(self, src_path, dest_path):
         copy_tree(src_path, dest_path)
-        subprocess.check_call(["git", "init", "--initial-branch=main", dest_path])
+        subprocess.check_call(["git", "init", dest_path])
         # Notice we needed a previous os.chdir to repository directory
         subprocess.check_call(["git", "add", "-A"])
 


### PR DESCRIPTION
git old version are not compatible with this option

I think it is not even needed to use it here