### PR TITLE
[FIX] eslint: Fix 'import' sentence error

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.eslintrc.json
+++ b/src/pre_commit_vauxoo/cfg/.eslintrc.json
@@ -237,6 +237,7 @@
     "yoda": "error"
   },
   "parserOptions": {
-    "ecmaVersion": "2021"
+    "ecmaVersion": "2021",
+    "sourceType": "module"
   }
 }


### PR DESCRIPTION
Fix the following error

  Parsing error: 'import' and 'export' may appear only with 'sourceType: module'

Fixing using the following solution:
  https://github.com/AtomLinter/linter-eslint/issues/462#issuecomment-190770417