### PR TITLE
[REF] pre-commit-vauxoo: Fix missing newline for pyproject.toml

### DIFF
--- a/src/pre_commit_vauxoo/pre_commit_vauxoo.py
+++ b/src/pre_commit_vauxoo/pre_commit_vauxoo.py
@@ -127,7 +127,7 @@ def copy_cfg_files(
                     )
                     line = line.replace("R0000", ",".join(pylint_disable_checks))
                 if fname == "pyproject.toml" and line.startswith("skip-string-normalization"):
-                    line = "skip-string-normalization=%s" % (skip_string_normalization and "true" or "false")
+                    line = "skip-string-normalization=%s\n" % (skip_string_normalization and "true" or "false")
                 if fname.startswith(".pylintrc"):
                     if "# External scripts odoo_lint replace" in line and odoo_version:
                         line += "valid-odoo-version=%s\n" % odoo_version


### PR DESCRIPTION
If you have added to git the file `pyproject.toml` it shows the following error:

```txt
2022-12-15 18:08:48,722 INFO pre-commit-vauxoo: ------------------------- AUTOFIX CHECKS -------------------------
2022-12-15 18:08:48,723 INFO pre-commit-vauxoo: Running autofix checks (affect status build but you can autofix them locally)
2022-12-15 18:08:48,723 DEBUG pre-commit-vauxoo: Running command: pre-commit run --color=always --all -c .pre-commit-config-autofix.yaml
black....................................................................Passed
autoflake................................................................Passed
prettier (with plugin-xml)...............................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook
Fixing pyproject.toml
```

Even if you fix the issue the problem is reproduced again and again

The reason is that the script is generating the file without newline

This PR add that missing newline