### PR TITLE
Include migrations script for versions 15 and higher

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
@@ -16,7 +16,7 @@ exclude: |
     (LICENSE.*|COPYING.*)|
     (\.travis\.yml|\.gitlab\-ci\.yml|\.pre\-commit\-config*\.yaml)|
     # It was ignored from original MQT since that there is not init file
-    (/migrations/)|
+    (/migrations/1[0-4])|
     (/doc/|/docs/)|
     (/tests/data/)|
     # EXCLUDE_LINT (Don't delete this line because if used from MQT)

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
@@ -16,7 +16,7 @@ exclude: |
     (LICENSE.*|COPYING.*)|
     (\.travis\.yml|\.gitlab\-ci\.yml|\.pre\-commit\-config*\.yaml)|
     # It was ignored from original MQT since that there is not init file
-    (/migrations/)|
+    (/migrations/1[0-4])|
     (/doc/|/docs/)|
     # EXCLUDE_LINT (Don't delete this line because if used from MQT)
     # Legacy modules absa: galaxy

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ exclude: |
     (LICENSE.*|COPYING.*)|
     (\.travis\.yml|\.gitlab\-ci\.yml|\.pre\-commit\-config*\.yaml)|
     # It was ignored from original MQT since that there is not init file
-    (/migrations/)|
+    (/migrations/1[0-4])|
     (/doc/|/docs/)|
     # EXCLUDE_LINT (Don't delete this line because if used from MQT)
     # Legacy modules absa: galaxy


### PR DESCRIPTION
Fixes #97. Due to historical reasons migration scripts were excluded, however starting from version 15.0 and on, they will be considered in checks. Therefore the configuration files regex were updated accordingly.