### PR TITLE
[FIX] non-installable module regex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Overview
 
 .. |codecov| image:: https://codecov.io/gh/Vauxoo/pre-commit-vauxoo/branch/main/graphs/badge.svg?branch=main
     :alt: Coverage Status
-    :target: https://codecov.io/github/Vauxoo/pre-commit-vauxoo
+    :target: https://app.codecov.io/github/Vauxoo/pre-commit-vauxoo
 
 .. |version| image:: https://img.shields.io/pypi/v/pre-commit-vauxoo.svg
     :alt: PyPI Package latest release

--- a/src/pre_commit_vauxoo/pre_commit_vauxoo.py
+++ b/src/pre_commit_vauxoo/pre_commit_vauxoo.py
@@ -2,6 +2,7 @@ import ast
 import glob
 import logging
 import os
+import posixpath
 import re
 import shutil
 import subprocess
@@ -69,7 +70,7 @@ def get_uninstallable_modules(src_path) -> set:
         with open(path) as manifest:
             try:
                 if not ast.literal_eval(manifest.read()).get("installable", True):
-                    results.add(os.path.dirname(os.path.relpath(path, start=src_path)))
+                    results.add(posixpath.join(os.path.dirname(os.path.relpath(path, start=src_path)), ""))
             except (ValueError, TypeError, SyntaxError, AttributeError):
                 _logger.info("Unable to parse manifest at %s. Considering it installable", path)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,4 @@ pytest-xdist
 tox
 twine
 wheel
+pyyaml


### PR DESCRIPTION
This fixes #102. Previously the auto generated regex to exclude a module named "dummy" would also exclude any other module whose name started with "dummy".

The regex has been fixed and "dummy" can now be automatically excluded without excluding "dummy_subscription" or other similarly named repos.