### PR TITLE
[IMP] update odoo-pre-commit-hooks, add po-pretty-format, oe_structure

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Upgrade pre-commit-vauxoo to the latest version (w/o update dependencies if not needed)
         run: >-
-          pip3 install -U . &&
+          pip3 install --ignore-installed -U . &&
           pip3 install --force-reinstall --no-deps .
       - name: Run pre-commit-vauxoo
         run: pre-commit-vauxoo

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
@@ -99,3 +99,8 @@ repos:
           - --color
           - --config=.eslintrc.json
           - --fix
+  - repo: https://github.com/OCA/odoo-pre-commit-hooks
+    rev: v0.0.27
+    hooks:
+      - id: oca-checks-po
+        args: ["--enable=po-pretty-format", "--fix"]

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
@@ -38,10 +38,11 @@ repos:
           # External scripts
           - --disable=R0000
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
-    rev: v0.0.21
+    rev: v0.0.27
     hooks:
       - id: oca-checks-odoo-module
       - id: oca-checks-po
+        args: ["--disable=po-pretty-format"]
   - repo: https://github.com/PyCQA/doc8
     rev: v1.0.0
     hooks:


### PR DESCRIPTION
`po-pretty-format` has been added as a new hook (on 0.0.26) to odoo-pre-commit-hooks, this commit adds this new hook with autofix enabled.

It has also been disabled from the optional configuration, since it will be already run in the autofix one.

In this release another check has also been added, to prevent tags with oe_structure as class from not having an ID.

Related to hook: https://github.com/OCA/odoo-pre-commit-hooks/pull/76
Related to issue: https://github.com/Vauxoo/pre-commit-vauxoo/issues/104