### PR TITLE
[REF] cfg: Update bandit version and disable defusedxml checks

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.bandit
+++ b/src/pre_commit_vauxoo/cfg/.bandit
@@ -1,8 +1,10 @@
 [bandit]
 exclude = tests
 
-# B608:hardcoded_sql_expressions they are considered from pylint-odoo
-skips = B608
+# B608: hardcoded_sql_expressions they are considered from pylint-odoo
+# B313,B314,B315,B316,B317,B318,B319,B320,B410: defusedxml checks
+#   Odoo's team via inbox twitter is not convinced to repair them and the entire Odoo is raising these checks
+skips = B608,B313,B314,B315,B316,B317,B318,B319,B320,B410
 
 format = custom
 msg-template={relpath}:{line}:{col} {msg} - [{test_id}] - ({severity})

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
@@ -57,7 +57,7 @@ repos:
         args:
           - --config=.flake8-optional
   - repo: https://github.com/PyCQA/bandit
-    rev: d9fe642e01
+    rev: 1.7.5
     hooks:
       - id: bandit
         name: bandit EXPERIMENTAL (Won't affect CI status)!


### PR DESCRIPTION
Since that Odoo's team via inbox twitter is not convinced to repair them and the entire Odoo is raising these checks Disabled since that doesn't have sense to repair all the modules but the odoo core will have the risk