### PR TITLE
[REF] Disable xml-oe-structure-id

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
@@ -41,6 +41,7 @@ repos:
     rev: v0.0.28
     hooks:
       - id: oca-checks-odoo-module
+        args: ["--disable=xml-oe-structure-id"]
       - id: oca-checks-po
         args: ["--disable=po-pretty-format"]
   - repo: https://github.com/PyCQA/doc8


### PR DESCRIPTION
Due to internal reasons, xml-oe-structure-id won't be implemented in Vauxoo for the time being, therefore it has been disabled.