### PR TITLE
[REF] use config files for oca-hooks

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.oca_hooks-autofix.cfg
+++ b/src/pre_commit_vauxoo/cfg/.oca_hooks-autofix.cfg
@@ -1,0 +1,2 @@
+[MESSAGES_CONTROL]
+enable=po-pretty-format

--- a/src/pre_commit_vauxoo/cfg/.oca_hooks.cfg
+++ b/src/pre_commit_vauxoo/cfg/.oca_hooks.cfg
@@ -1,0 +1,2 @@
+[MESSAGES_CONTROL]
+disable=xml-oe-structure-missing-id,po-pretty-format

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
@@ -103,4 +103,6 @@ repos:
     rev: v0.0.28
     hooks:
       - id: oca-checks-po
-        args: ["--enable=po-pretty-format", "--fix"]
+        args:
+          - --config=.oca_hooks-autofix.cfg
+          - --fix

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
@@ -41,9 +41,7 @@ repos:
     rev: v0.0.28
     hooks:
       - id: oca-checks-odoo-module
-        args: ["--disable=xml-oe-structure-missing-id"]
       - id: oca-checks-po
-        args: ["--disable=po-pretty-format"]
   - repo: https://github.com/PyCQA/doc8
     rev: v1.0.0
     hooks:


### PR DESCRIPTION
Closes #111.

All settings which can be set through a configuration file for odoo-pre-commit-hooks have been moved to their respective config file.