### PR TITLE
[IMP] cfg: update oca odoo hooks version

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
@@ -100,7 +100,7 @@ repos:
           - --config=.eslintrc.json
           - --fix
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
-    rev: v0.0.28
+    rev: v0.0.29
     hooks:
       - id: oca-checks-po
         args:

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
@@ -38,7 +38,7 @@ repos:
           # External scripts
           - --disable=R0000
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
-    rev: v0.0.28
+    rev: v0.0.29
     hooks:
       - id: oca-checks-odoo-module
       - id: oca-checks-po


### PR DESCRIPTION
Config files have been updated to use the new release of odoo hooks.