### PR TITLE
[IMP] support disabling oca hooks through env var

### DIFF
--- a/src/pre_commit_vauxoo/cli.py
+++ b/src/pre_commit_vauxoo/cli.py
@@ -240,6 +240,14 @@ PRECOMMIT_HOOKS_TYPE += ["all"] + ["-%s" % i for i in PRECOMMIT_HOOKS_TYPE]
     **new_extra_kwargs,
 )
 @click.option(
+    "--oca-hooks-disable-checks",
+    type=CSVStringParamType(),
+    callback=merge_tuples,
+    envvar="OCA_HOOKS_DISABLE_CHECKS",
+    help="OCA Hooks checks to disable, separated by commas.",
+    **new_extra_kwargs,
+)
+@click.option(
     "--skip-string-normalization",
     "-S",
     envvar="BLACK_SKIP_STRING_NORMALIZATION",

--- a/src/pre_commit_vauxoo/pre_commit_vauxoo.py
+++ b/src/pre_commit_vauxoo/pre_commit_vauxoo.py
@@ -83,6 +83,7 @@ def copy_cfg_files(
     no_overwrite,
     exclude_lint,
     pylint_disable_checks,
+    oca_hooks_disable_checks,
     exclude_autofix,
     skip_string_normalization,
     odoo_version,
@@ -127,6 +128,12 @@ def copy_cfg_files(
                         "Disabling the following pylint checks (PYLINT_DISABLE_CHECKS): %s", pylint_disable_checks
                     )
                     line = line.replace("R0000", ",".join(pylint_disable_checks))
+                if oca_hooks_disable_checks and fname.startswith(".oca_hooks.cfg") and "disable=" in line:
+                    _logger.info(
+                        "Disabling the following oca hooks checks (OCA_HOOKS_DISABLE_CHECKS): %s",
+                        oca_hooks_disable_checks,
+                    )
+                    line = line.replace("\n", f',{",".join(oca_hooks_disable_checks)}\n')
                 if fname == "pyproject.toml" and line.startswith("skip-string-normalization"):
                     line = "skip-string-normalization=%s\n" % (skip_string_normalization and "true" or "false")
                 if fname.startswith(".pylintrc"):
@@ -171,6 +178,7 @@ def main(
     exclude_autofix,
     exclude_lint,
     pylint_disable_checks,
+    oca_hooks_disable_checks,
     precommit_hooks_type,
     fail_optional,
     install,
@@ -203,6 +211,7 @@ def main(
         no_overwrite,
         exclude_lint,
         pylint_disable_checks,
+        oca_hooks_disable_checks,
         exclude_autofix,
         skip_string_normalization,
         odoo_version,

--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -192,6 +192,17 @@ class TestPreCommitVauxoo(unittest.TestCase):
         self.assertTrue(pattern.search(posixpath.join(repo_path, "models", "res_partner.py")))
         self.assertIsNone(pattern.search(posixpath.join(repo_sub_path, "wizard", "invoice_send.py")))
 
+    def test_disable_oca_hooks(self):
+        os.environ["OCA_HOOKS_DISABLE_CHECKS"] = "random-message"
+        self.runner.invoke(main, [])
+        with open(os.path.join(self.tmp_dir, ".oca_hooks.cfg")) as hooks_cfg:
+            f_content = hooks_cfg.read()
+        self.assertIn(
+            "disable=xml-oe-structure-missing-id,po-pretty-format,random-message",
+            f_content,
+            "random-message was supposed to be disabled through the corresponding environment variable",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -79,7 +79,6 @@ class TestPreCommitVauxoo(unittest.TestCase):
             self.assertIn("skip-string-normalization=false", f_pyproject.read(), "Skip string normalization not set")
 
     def test_chdir(self):
-        self.runner = CliRunner()
         os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"
         os.chdir("module_autofix1")
         expected_logs = ["WARNING:pre-commit-vauxoo:Running in current directory 'module_autofix1'"]
@@ -89,8 +88,6 @@ class TestPreCommitVauxoo(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, "Exited with error %s - %s" % (result, result.output))
 
     def test_exclude_lint_path(self):
-        self.runner = CliRunner()
-
         os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"
         os.environ["BLACK_SKIP_STRING_NORMALIZATION"] = "false"
         os.environ["EXCLUDE_LINT"] = "module_example1/models"
@@ -101,7 +98,6 @@ class TestPreCommitVauxoo(unittest.TestCase):
         self.assertIn("skip-string-normalization=false", f_content, "Skip string normalization not set")
 
     def test_disable_lints(self):
-        self.runner = CliRunner()
         os.environ["DISABLE_PYLINT_CHECKS"] = "import-error"
         result = self.runner.invoke(main, [])
         self.assertEqual(result.exit_code, 0, "Exited with error %s - %s" % (result, result.output))
@@ -110,8 +106,6 @@ class TestPreCommitVauxoo(unittest.TestCase):
         self.assertIn("import-error,", f_content, "import-error was not disabled")
 
     def test_exclude_autofix(self):
-        self.runner = CliRunner()
-
         os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"
         os.environ["EXCLUDE_AUTOFIX"] = "module_example1/demo/"
         os.environ["BLACK_SKIP_STRING_NORMALIZATION"] = "true"

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands =
 
 [testenv:lint]
 # skip_install = true
-basepython = {env:TOXPYTHON:python3.10}
+basepython = {env:TOXPYTHON:python3.11}
 commands =
     pre-commit-vauxoo
 


### PR DESCRIPTION
Closes https://github.com/Vauxoo/pre-commit-vauxoo/issues/115.

As is the case with pylint, this commit adds support for the environment
variable `OCA_HOOKS_DISABLE_CHECKS`. Checks must be listed in it as a
comma separated list, said checks will be added to the disable section
of oca_hooks.cfg, effectively disabling them.

This lets projects disable checks through variables.sh