### PR TITLE
[REF] tox: Build ChangeLog again

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,12 +40,6 @@ commands =
     sphinx-build -b linkcheck docs dist/docs
 
 [testenv:build]
-skip_install = true
-deps =
-    build
-    bump2version
-    twine
-    wheel
 commands =
     python -m build --sdist --wheel --outdir dist_wo_pbr/
     python -c "import shutil;shutil.rmtree('dist/', ignore_errors=True)"


### PR DESCRIPTION
ChangeLog requires 'pbr'

But the tox build was installing requirements manually instead of installing the test-requirements.txt file were all them are considered