### PR TITLE
ci: Update actions/checkout

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -21,7 +21,7 @@ jobs:
       PIP_CACHE_DIR: "/root/.cache/pip"
       PRE_COMMIT_HOME: "/root/.cache/pre-commit"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Upgrade pre-commit-vauxoo to the latest version (w/o update dependencies if not needed)
         run: >-
           pip3 install --ignore-installed -U . &&


### PR DESCRIPTION
actions/checkout was updated from v2 to v3, v2 is using Node 12 which is
deprecated and is scheduled to stop working on github pipelines.

Closes https://github.com/Vauxoo/pre-commit-vauxoo/issues/121.