### PR TITLE
Update CI/RTD

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         path: ~/.cache/pre-commit
         key: ${{ runner.os }}-py${{ matrix.python }}-pre-commit
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: actions/setup-python@v4

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,5 @@
 # pylint: disable=invalid-name,redefined-builtin
 
-import os
 
 extensions = [
     "sphinx.ext.autodoc",
@@ -27,12 +26,8 @@ extlinks = {
     "issue": ("https://github.com/Vauxoo/pre-commit-vauxoo/issues/%s", "#"),
     "pr": ("https://github.com/Vauxoo/pre-commit-vauxoo/pull/%s", "PR #"),
 }
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
-if not on_rtd:  # only set the theme if we're building docs locally
-    html_theme = "sphinx_rtd_theme"
-
+html_theme = "sphinx_rtd_theme"
 html_use_smartypants = True
 html_last_updated_fmt = "%b %d, %Y"
 html_split_index = False


### PR DESCRIPTION
The previous PR related to deprecated actions/checkout@v2 missed usage on another job and did not update it. This also introduces what seems to be a fix to the read the docs build process (badge and logs show the builds are failing as of now).