### PR TITLE
[REF] Remove redundant autofix checks

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
@@ -84,10 +84,6 @@ repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.3.1
     hooks:
-      - id: forbid-crlf
-      - id: remove-crlf
-      - id: forbid-tabs
-        exclude: (Makefile|debian/rules|.gitmodules|\.po|\.pot)(\.in)?$
       - id: remove-tabs
         exclude: (Makefile|debian/rules|.gitmodules|\.po|\.pot)(\.in)?$
   - repo: https://github.com/pre-commit/mirrors-eslint


### PR DESCRIPTION
Some checks that performed the same thing (e.g. fix line endings) have been removed to leave only one. Also removed all forbid hooks that  have a remove hook available (which does the same thing and autofixes).

Closes #124.