### PR TITLE
[IMP] cfg: update black version

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
@@ -30,7 +30,7 @@ default_language_version:
   node: "14.13.0"
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror.git
-    rev: 22.10.0
+    rev: 23.12.1
     hooks:
       - id: black
   - repo: https://github.com/myint/autoflake

--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -26,7 +26,7 @@ class TestPreCommitVauxoo(unittest.TestCase):
         super().setUp()
         self.old_environ = os.environ.copy()
         self.original_work_dir = os.getcwd()
-        self.tmp_dir = tempfile.mkdtemp(suffix="_pre_commit_vauxoo")
+        self.tmp_dir = os.path.realpath(tempfile.mkdtemp(suffix="_pre_commit_vauxoo"))
         os.chdir(self.tmp_dir)
         self.runner = CliRunner()
         src_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "resources")


### PR DESCRIPTION
Autofix hooks have been updated to their latest version. Biggest change involves black removing whitespaces after class/method declarations.

BREAKING CHANGE: black may generate diffs on projects