### PR TITLE
[IMP] cfg: update pylint-odoo

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
@@ -29,7 +29,7 @@ default_language_version:
   node: "14.13.0"
 repos:
   - repo: https://github.com/OCA/pylint-odoo
-    rev: v9.0.4
+    rev: v9.0.5
     hooks:
       - id: pylint_odoo
         name: pylint optional checks

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: flake8
         name: flake8 mandatory checks
   - repo: https://github.com/OCA/pylint-odoo
-    rev: v9.0.0
+    rev: v9.0.5
     hooks:
       - id: pylint_odoo
         name: pylint mandatory checks


### PR DESCRIPTION
The version of pylint-odoo used by hooks has been updated to its latest (v9.0.5).