### PR TITLE
[ADD] adds new hook: prevents files from having whitespaces in their name

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
@@ -52,6 +52,12 @@ repos:
           # - --fix
   - repo: local
     hooks:
+      - id: name-non-ascii
+        name: Use only ASCII (no accents or special characters) for filenames and directory names
+        description: It may raise errors on OS without locale settings configured
+        entry: Use only ASCII (no accents or special characters) for filenames and directory names
+        language: fail
+        files: '[^\x00-\x7F]'
       - id: vx-check-deactivate
         name: deactivate.jinja syntax check.
         description: Validate deactivate.jinja files' syntax.

--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -241,6 +241,30 @@ class TestPreCommitVauxoo(unittest.TestCase):
 
                 self.assertFalse(duplicates, f"Duplicate messages found in {rc_file}")
 
+    def test_special_char_filename(self):
+        os.environ["PRECOMMIT_HOOKS_TYPE"] = "mandatory"
+        fname_wrong = os.path.join(self.tmp_dir, "module_example1", "leéme.rst")
+        with open(fname_wrong, "w"):
+            pass
+        subprocess.check_call(["git", "add", "-A"])
+        expected_logs = ["ERROR:pre-commit-vauxoo:Mandatory checks failed"]
+        with self.custom_assert_logs("pre-commit-vauxoo", level="ERROR", expected_logs=expected_logs):
+            result = self.runner.invoke(main, [])
+        self.assertEqual(result.exit_code, 1, "Exited without error")
+
+    def test_special_char_dirname(self):
+        os.environ["PRECOMMIT_HOOKS_TYPE"] = "mandatory"
+        dirname_wrong = os.path.join(self.tmp_dir, "module_example1", "moisé")
+        os.mkdir(dirname_wrong)
+        fname = os.path.join(dirname_wrong, "empty_file.txt")
+        with open(fname, "w"):
+            pass
+        subprocess.check_call(["git", "add", "-A"])
+        expected_logs = ["ERROR:pre-commit-vauxoo:Mandatory checks failed"]
+        with self.custom_assert_logs("pre-commit-vauxoo", level="ERROR", expected_logs=expected_logs):
+            result = self.runner.invoke(main, [])
+        self.assertEqual(result.exit_code, 1, "Exited without error")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds a `fail` language hook to validate filenames. This particular hook simply verifies that the filename does not contain spaces, but it can be extended to more general requirements.