### PR TITLE
[REV] pre-commit-config: Revert enable jobs for pylint hook

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
@@ -37,7 +37,8 @@ repos:
           - --rcfile=.pylintrc-optional
           # External scripts
           - --disable=R0000
-          - --jobs=0  # 0 will auto-detect the number of processors available to use
+          # uncomment after fix https://github.com/OCA/pylint-odoo/pull/512
+          # - --jobs=0  # 0 will auto-detect the number of processors available to use
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
     rev: v0.0.35
     hooks:

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
@@ -41,7 +41,8 @@ repos:
         args:
           # External scripts
           - --disable=R0000
-          - --jobs=0  # 0 will auto-detect the number of processors available to use
+          # uncomment after fix https://github.com/OCA/pylint-odoo/pull/512
+          # - --jobs=0  # 0 will auto-detect the number of processors available to use
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.51.0
     hooks:


### PR DESCRIPTION
New pylint-odoo version is compatible to use multiple jobs and this commit enables the option in order to run faster

However, there is a pending issue to fix:
 - https://github.com/OCA/pylint-odoo/pull/512

So, consider-merging-classes-inherited could be not raised