### PR TITLE
[FIX] eslint: Update .eslintrc.json to use ECMAScript 2022

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.eslintrc.json
+++ b/src/pre_commit_vauxoo/cfg/.eslintrc.json
@@ -237,7 +237,7 @@
     "yoda": "error"
   },
   "parserOptions": {
-    "ecmaVersion": "2021",
+    "ecmaVersion": 2022,
     "sourceType": "module"
   }
 }


### PR DESCRIPTION
Changed ecmaVersion in parserOptions from 2021 to 2022 to enable support for newer ECMAScript features. Ensures compatibility with the latest JavaScript syntax improvements and standards.

Odoo Version:
https://github.com/odoo/odoo/blob/17.0/addons/web/tooling/_eslintrc.json#L5

Fix the following error
  `Parsing error: Unexpected token =`