### PR TITLE
[REF] pre_commit_vauxoo: Update pylint version

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
         tox_env: ['py']
         include:
@@ -56,8 +56,6 @@ jobs:
         exclude:
           # macos-14 AKA macos-latest has switched to being an ARM runner, only supporting newer versions of Python
           # https://github.com/actions/setup-python/issues/825#issuecomment-2096792396
-          - python: '3.8'
-            os: macos-latest
           - python: '3.9'
             os: macos-latest
           - python: '3.10'

--- a/README.rst
+++ b/README.rst
@@ -186,6 +186,21 @@ To run all the tests run::
 
     tox
 
+Use extra parameters to change the test behaviour.
+
+e.g. particular python version::
+
+    tox -e py310
+
+e.g. particular unittest method::
+
+    tox -e py310 -- -k test_basic
+
+e.g. all the tests at the same time in parallel::
+
+    tox -p auto
+
+
 Note, to combine the coverage data from all the tox environments run:
 
 .. list-table::

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,11 +31,10 @@ skip = .tox,.eggs,ci/templates,build,dist
 #  - can use as many you want
 
 python_versions =
-    py27
-    py36
-    py37
-    py38
     py39
+    py310
+    py311
+    py312
     pypy
     pypy3
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -84,7 +83,7 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=generate_dependencies(),
     extras_require={
         # eg:

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
@@ -29,7 +29,7 @@ default_language_version:
   node: "14.13.0"
 repos:
   - repo: https://github.com/OCA/pylint-odoo
-    rev: v9.2.0
+    rev: v9.3.2
     hooks:
       - id: pylint_odoo
         name: pylint optional checks

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
@@ -34,11 +34,12 @@ repos:
       - id: flake8
         name: flake8 mandatory checks
   - repo: https://github.com/OCA/pylint-odoo
-    rev: v9.2.0
+    rev: v9.3.2
     hooks:
       - id: pylint_odoo
         name: pylint mandatory checks
         args:
+          - --rcfile=.pylintrc
           # External scripts
           - --disable=R0000
           # uncomment after fix https://github.com/OCA/pylint-odoo/pull/512

--- a/src/pre_commit_vauxoo/cfg/.pylintrc
+++ b/src/pre_commit_vauxoo/cfg/.pylintrc
@@ -1,4 +1,4 @@
-[MASTER]
+[MAIN]
 ignore=CVS,.git,scenarios,LICENSE,*.md
 persistent=yes
 # This extension are not used for this configuration file but are useful to process disable comments based on these ones
@@ -65,6 +65,7 @@ disable=abstract-method,
    too-many-branches,
    too-many-function-args,
    too-many-instance-attributes,
+   too-many-positional-arguments,
    too-many-statements,
    try-except-raise,
    unexpected-keyword-arg,
@@ -158,6 +159,7 @@ disable=abstract-method,
 # ungrouped-imports: We uses a lot "from odoo import fields;from odoo.tools import ..." so it is a valid case for us
 # duplicate-code: Enable after fix https://github.com/PyCQA/pylint/issues/214
 # assignment-from-no-return: pylint doesn't have the full context of all modules even we could return the same
+# useless-option-value: Raises error when a check doesn't exists but what about multi-compatibility
 
 #***Enabled and how to fix***
 #E1103 - maybe-no-member

--- a/src/pre_commit_vauxoo/cfg/.pylintrc-optional
+++ b/src/pre_commit_vauxoo/cfg/.pylintrc-optional
@@ -1,5 +1,4 @@
-[MASTER]
-profile=no
+[MAIN]
 ignore=CVS,.git,scenarios,.bzr
 persistent=yes
 load-plugins=pylint.extensions.docstyle, pylint.extensions.mccabe, pylint_odoo
@@ -19,7 +18,7 @@ manifest-deprecated-keys=description,active
 # External scripts odoo_lint replace
 
 [MESSAGES CONTROL]
-disable=all
+disable=all,unknown-option-value
 enable=attribute-deprecated,
   attribute-string-redundant,
   bad-builtin-groupby,
@@ -74,13 +73,11 @@ enable=attribute-deprecated,
   use-symbolic-message-instead,
   use-vim-comment,
   useless-parent-delegation,
-  useless-option-value,
   website-manifest-key-not-valid-uri
 
 [REPORTS]
 msg-template={path}:{line}:{column}: ({symbol}) {msg}
 output-format=colorized
-files-output=no
 reports=no
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 score=no

--- a/src/pre_commit_vauxoo/hooks/check_deactivate_jinja.py
+++ b/src/pre_commit_vauxoo/hooks/check_deactivate_jinja.py
@@ -54,11 +54,13 @@ def check_deactivate(fname_deactivate, instance_types=None):
             # Return instead of continue because the package is not installed
             return res
         if not res:
+            only_msg = msg
+            sql_line_error = sql
             error_re = re.search(r"^line (\d+): ([^/]+)", msg)
             if error_re:
                 sql_lineno, only_msg = error_re.groups()
                 sql_lineno = int(sql_lineno)
-            sql_line_error = "\n".join(sql.splitlines()[sql_lineno - 1 : sql_lineno])  # noqa: E203
+                sql_line_error = "\n".join(sql.splitlines()[sql_lineno - 1 : sql_lineno])
             print(
                 "%s->json->sql instance_type=%s - %s\n\t%s\nsql content:\n%s"
                 % (fname_deactivate, instance_type, only_msg, sql_line_error, sql)

--- a/src/pre_commit_vauxoo/pre_commit_vauxoo.py
+++ b/src/pre_commit_vauxoo/pre_commit_vauxoo.py
@@ -128,11 +128,14 @@ def copy_cfg_files(
                     if fname == ".pre-commit-config-autofix.yaml" and exclude_autofix:
                         _logger.info("Applying EXCLUDE_AUTOFIX=%s to %s", exclude_autofix, dst)
                         line += "    %s\n" % exclude_autofix_regex
-                if pylint_disable_checks and fname.startswith(".pre-commit-config") and "--disable=R0000" in line:
-                    _logger.info(
-                        "Disabling the following pylint checks (PYLINT_DISABLE_CHECKS): %s", pylint_disable_checks
-                    )
-                    line = line.replace("R0000", ",".join(pylint_disable_checks))
+                if fname.startswith(".pre-commit-config") and "--disable=R0000" in line:
+                    if pylint_disable_checks:
+                        _logger.info(
+                            "Disabling the following pylint checks (PYLINT_DISABLE_CHECKS): %s", pylint_disable_checks
+                        )
+                        line = line.replace("R0000", ",".join(pylint_disable_checks))
+                    else:
+                        line = ""
                 if oca_hooks_disable_checks and fname.startswith(".oca_hooks.cfg") and "disable=" in line:
                     _logger.info(
                         "Disabling the following oca hooks checks (OCA_HOOKS_DISABLE_CHECKS): %s",

--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -36,7 +36,7 @@ class TestPreCommitVauxoo(unittest.TestCase):
 
     def create_dummy_repo(self, src_path, dest_path):
         copy_tree(src_path, dest_path)
-        subprocess.check_call(["git", "init", dest_path])
+        subprocess.check_call(["git", "init", dest_path, "--initial-branch=main"])
         # Notice we needed a previous os.chdir to repository directory
         subprocess.check_call(["git", "add", "-A"])
 
@@ -228,7 +228,7 @@ class TestPreCommitVauxoo(unittest.TestCase):
             config = ConfigParser()
             config.read(rc_file)
             for action in ["enable", "disable"]:
-                if config["MESSAGES CONTROL"][action] == "all":
+                if "all" in config["MESSAGES CONTROL"][action].split(","):
                     continue
 
                 messages = config["MESSAGES CONTROL"][action].split(",\n")


### PR DESCRIPTION
Realted to https://github.com/OCA/pylint-odoo/pull/515

# Analyze new checks:
- [ ] contextmanager-generator-missing-cleanup
- [ ] declare-non-slot
- [ ] possibly-used-before-assignment
- [ ] using-assignment-expression-in-unsupported-version
- [ ] using-exception-groups-in-unsupported-version
- [ ] using-generic-type-syntax-in-unsupported-version
- [ ] using-positional-only-args-in-unsupported-version

To install this version use:
 - `pip install --force-reinstall -U git+https://github.com/Vauxoo-dev/pre-commit-vauxoo@main-upd-pycfg-moy.git`
