### PR TITLE
[REF] pylint_odoo: Update pylint version to v9.3.3

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
@@ -29,7 +29,7 @@ default_language_version:
   node: "14.13.0"
 repos:
   - repo: https://github.com/OCA/pylint-odoo
-    rev: v9.3.2
+    rev: v9.3.3
     hooks:
       - id: pylint_odoo
         name: pylint optional checks

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: flake8
         name: flake8 mandatory checks
   - repo: https://github.com/OCA/pylint-odoo
-    rev: v9.3.2
+    rev: v9.3.3
     hooks:
       - id: pylint_odoo
         name: pylint mandatory checks


### PR DESCRIPTION
Check release notes:
 - https://pypi.org/project/pylint-odoo

v9.3.3
[FIX] prohibited-method-override: Check if caller has a func attribute (https://github.com/OCA/pylint-odoo/pull/524) [ADD] deprecated-name-get: name_get deprecated since v17 (https://github.com/OCA/pylint-odoo/pull/526) [ADD] manifest-external-assets: No external sources for assets (https://github.com/OCA/pylint-odoo/pull/525)