### PR TITLE
[REF] pylint_odoo: Update pylint version to v9.3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click
+click<=8.1.8
 pre-commit
 jinja2
 pgsanity

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
@@ -29,7 +29,7 @@ default_language_version:
   node: "14.13.0"
 repos:
   - repo: https://github.com/OCA/pylint-odoo
-    rev: v9.3.3
+    rev: v9.3.6
     hooks:
       - id: pylint_odoo
         name: pylint optional checks

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: flake8
         name: flake8 mandatory checks
   - repo: https://github.com/OCA/pylint-odoo
-    rev: v9.3.3
+    rev: v9.3.6
     hooks:
       - id: pylint_odoo
         name: pylint mandatory checks


### PR DESCRIPTION
* [REF] pylint_odoo: Update pylint version to v9.3.6

        Check release notes:
         - https://pypi.org/project/pylint-odoo/9.3.6

        [ADD] inheritable-method-string: Add check to preserve inheritability for compute, search and inverse,  (https://github.com/OCA/pylint-odoo/pull/528)
        [ADD] inheritable-method-lambda: Add check to be inheritable the domain and default using lambda (https://github.com/OCA/pylint-odoo/pull/529)


[FIX] click: Pinned 'click' version where it is compatibility

    New changes for 'click' package are not compatible

    TODO: Update latest click version and do it compatible

