### PR TITLE
[REF] cfg: Upgrade oca-odoo-pre-commit-hooks v0.1.2

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml
@@ -92,7 +92,7 @@ repos:
           - --config=.eslintrc.json
           - --fix
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
-    rev: v0.0.35
+    rev: v0.1.2
     hooks:
       - id: oca-checks-po
         args:

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml
@@ -40,7 +40,7 @@ repos:
           # uncomment after fix https://github.com/OCA/pylint-odoo/pull/512
           # - --jobs=0  # 0 will auto-detect the number of processors available to use
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
-    rev: v0.0.35
+    rev: v0.1.2
     hooks:
       - id: oca-checks-odoo-module
       - id: oca-checks-po


### PR DESCRIPTION
 * https://github.com/OCA/odoo-pre-commit-hooks/pull/127
   - Fix https://github.com/OCA/odoo-pre-commit-hooks/issues/74

 * https://github.com/OCA/odoo-pre-commit-hooks/pull/125
   - A new check has been added to check for deprecated chatters in modules version 18 and above. It was also necessary to extract module version for this new check to selectively enable/disable the new check.
   - Fix https://github.com/OCA/odoo-pre-commit-hooks/issues/121

And small fixes