### PR TITLE
[REF] github-actions: Use py3.14 pre-release

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -26,7 +26,7 @@ jobs:
       PIP_CACHE_DIR: "/root/.cache/pip"
       PRE_COMMIT_HOME: "/root/.cache/pre-commit"
     steps:
-      - uses: actions/checkout@v4.1.2
+      - uses: actions/checkout@v4
       - name: Upgrade pre-commit-vauxoo to the latest version (w/o update dependencies if not needed)
         run: >-
           pip3 install --ignore-installed -U . &&
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14-dev']
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
         tox_env: ['py']
         include:
@@ -72,10 +72,10 @@ jobs:
       with:
         path: ${{ env.PRE_COMMIT_CACHE }}
         key: ${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python }}-pre-commit
-    - uses: actions/checkout@v4.1.2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v5.0.0
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
         architecture: 'x64'

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ python_versions =
     py311
     py312
     py313
+    py314
     pypy
     pypy3
 

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         # 'Programming Language :: Python :: Implementation :: CPython',
         # 'Programming Language :: Python :: Implementation :: PyPy',
         # uncomment if you test on these interpreters:

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,9 @@ envlist =
     py39,
     py310,
     py311,
+    py312,
+    py313,
+    py314,
 
 [testenv]
 parallel_show_output=true


### PR DESCRIPTION
Set github actions version first level value in order to use latest minor releases