### PR TITLE
[REF] pre-commit-config: Update OCA/odoo-pre-commit-hooks to v0.1.7 for non-aggressive autofixes

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml.jinja
@@ -53,7 +53,7 @@ repos:
           - --config=.oca_hooks-autofix.cfg
           - --fix
 {%- else %}
-    rev: v0.1.4
+    rev: v0.1.7
     hooks:
       - id: oca-checks-po
         args:

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
@@ -49,7 +49,7 @@ repos:
 {%- if oca_hooks_matrix_value >= 20 %}
     rev: v0.2.20
 {%- else %}
-    rev: v0.1.4
+    rev: v0.1.7
 {%- endif %}
     hooks:
       - id: oca-checks-odoo-module


### PR DESCRIPTION
In order to have the following fix https://github.com/oca/odoo-pre-commit-hooks/pull/139