### PR TITLE
[REF] pylintrc: Set "pytz" as deprecated-module for odoo 20.0+

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pylintrc-optional.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pylintrc-optional.jinja
@@ -107,8 +107,6 @@ ignore-docstrings=yes
 [MISCELLANEOUS]
 notes=FIXME,TODO
 
-[IMPORTS]
-deprecated-modules=openerp.osv
 
 [DESIGN]
 # McCabe complexity cyclomatic threshold for too-complex check

--- a/src/pre_commit_vauxoo/cfg/.pylintrc.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pylintrc.jinja
@@ -369,7 +369,7 @@ good-names=_,cr,uid,id,ids,_logger,o,e,i,k,v,checks,fast_suite,maxDiff
 bad-names=
 
 [IMPORTS]
-deprecated-modules=regsub,TERMIOS,Bastion,rexec,pdb,pudb,ipdb,bs4
+deprecated-modules=regsub,TERMIOS,Bastion,rexec,pdb,pudb,ipdb,bs4{%- if odoo_version and odoo_version|float >= 20 %},pytz{%- endif %}
 
 [DESIGN]
 max-args=200

--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -501,3 +501,34 @@ class TestPreCommitVauxoo:
         with open(os.path.join(self.tmp_dir, ".pylintrc")) as pylintrc:
             f_content = pylintrc.read()
         assert "category-allowed-app" in f_content, "app check enabled for a project for non apps (default value)"
+
+    @pytest.mark.parametrize(
+        ("odoo_version", "expected_deprecated_modules"),
+        [
+            ("13.0", "openerp.osv,pdb,pudb,ipdb,bs4"),
+            ("20.0", "openerp.osv,pdb,pudb,ipdb,bs4,pytz"),
+        ],
+    )
+    def test_deprecated_modules_config(self, odoo_version, expected_deprecated_modules):
+        result = self.runner.invoke(main, ["--only-cp-cfg", "--odoo-version", odoo_version])
+        assert not result.exit_code, "Exited with error %s - %s" % (result, result.output)
+
+        expected_by_file = {
+            ".pylintrc": set(expected_deprecated_modules.split(",")) - {"openerp.osv"},
+        }
+        for pylintrc, expected_modules in expected_by_file.items():
+            config = ConfigParser(inline_comment_prefixes=("#", ";"))
+            config.read(os.path.join(self.tmp_dir, pylintrc))
+            deprecated_modules = {
+                item.strip()
+                for item in config.get("IMPORTS", "deprecated-modules").replace("\n", "").split(",")
+                if item.strip()
+            }
+            assert expected_modules.issubset(deprecated_modules)
+
+        config = ConfigParser(inline_comment_prefixes=("#", ";"))
+        config.read(os.path.join(self.tmp_dir, ".pylintrc"))
+        enabled = {
+            item.strip() for item in config["MESSAGES CONTROL"]["disable"].replace("\n", "").split(",") if item.strip()
+        }
+        assert "deprecated-module" not in enabled


### PR DESCRIPTION
For Odoo 20.0+ set pytz as deprecated

Odoo removed `pytz` usage in the following commit:
 - https://github.com/odoo/odoo/commit/6fdb36716aac5d2b084fb0faa94ccb2f3ee7f99c

Also, clean pylintrc-optional removing the deprecated-module configuration since that it is not enabled there