### PR TITLE
[FIX] .pre-commit-config*: remove hardcoded excludes

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml.jinja
@@ -18,7 +18,6 @@ exclude: |
     # It was ignored from original MQT since that there is not init file
     (/migrations/1[0-4])|
     (/doc/|/docs/)|
-    (/tests/data/)|
     {% if exclude_autofix_regex -%}
     {{ "# EXCLUDE_AUTOFIX" }}
     {{ exclude_autofix_regex }}
@@ -27,10 +26,7 @@ exclude: |
     {{ "# EXCLUDE_LINT" }}
     {{ exclude_lint_regex }}
     {%- endif %}
-    # Legacy modules absa: galaxy
-    (galaxy/)|
-    # External scripts
-    (scripts/)
+    (/tests/data/)
   )
 default_language_version:
   python: python3

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
@@ -17,15 +17,11 @@ exclude: |
     (\.travis\.yml|\.gitlab\-ci\.yml|\.pre\-commit\-config*\.yaml)|
     # It was ignored from original MQT since that there is not init file
     (/migrations/1[0-4])|
-    (/doc/|/docs/)|
     {% if exclude_lint_regex -%}
     {{ "# EXCLUDE_LINT" }}
     {{ exclude_lint_regex }}
     {%- endif %}
-    # Legacy modules absa: galaxy
-    (galaxy/)|
-    # External scripts
-    (scripts/)
+    (/doc/|/docs/)
   )
 default_language_version:
   python: python3

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml.jinja
@@ -17,15 +17,11 @@ exclude: |
     (\.travis\.yml|\.gitlab\-ci\.yml|\.pre\-commit\-config*\.yaml)|
     # It was ignored from original MQT since that there is not init file
     (/migrations/1[0-4])|
-    (/doc/|/docs/)|
     {% if exclude_lint_regex -%}
     {{ "# EXCLUDE_LINT" }}
     {{ exclude_lint_regex }}
     {%- endif %}
-    # Legacy modules absa: galaxy
-    (galaxy/)|
-    # External scripts
-    (scripts/)
+    (/doc/|/docs/)
   )
 default_language_version:
   python: python3


### PR DESCRIPTION
The `galaxy/` and `scripts/` exclusions were inherited from MQT when `pre-commit-vauxoo` was created. Since they are hardcoded in the templates, projects cannot disable them through a parameter or environment variable.

Remove both exclusions:
- `galaxy/` was specific to the ABSA customer, but the module is no longer installable and is therefore already ignored by linters
- `scripts/` was intended for external scripts, but it also excludes valid scripts included in skills and CLI implementations

Projects that need to exclude particular paths can use the existing configuration variables instead.