### PR TITLE
[FIX] .coveragerc: Omit "cfg/" templates from coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,6 +14,7 @@ omit =
     *__init__.py
     */tests/*
     *__main__.py
+    */cfg/*
 
 # Regexes for lines to exclude from consideration
 exclude_lines =


### PR DESCRIPTION
The `cfg/` directory ships non-Python config templates that are not meant to be measured as source code.

coverage's HTML reporter still picked them up when building the soft-keyword-highlighted report and tried to `ast.parse()` them as Python, causing an INTERNALERROR (SyntaxError: invalid syntax) and failing `tox -e py` even though all 180 tests passed.

Excluding `*/cfg/*` in `omit` keeps coverage scoped to actual Python source and avoids parsing non-Python template files.