### PR TITLE
[FIX] tests: Fix CI WIN forcing utf-8 encoding

### DIFF
--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -554,7 +554,7 @@ class TestPreCommitVauxoo:
     def test_pylint_cfg(self, version, manifest_deprecated_keys, tmp_path):
         cfg_content = render_template(version, ".pylintrc-optional.jinja")
         cfg_file = tmp_path / ".pylintrc-optional"
-        cfg_file.write_text(cfg_content)
+        cfg_file.write_text(cfg_content, encoding="utf-8")
 
         linter = PyLinter()
         linter.load_default_plugins()


### PR DESCRIPTION
Path.write_text() without encoding= falls back to
locale.getpreferredencoding(), which on Windows CI runners is cp1252/mbcs instead of utf-8.

The rendered .pylintrc-optional.jinja template contains a non-ASCII character (U+00A0 NBSP), which cp1252 encodes as a single byte (0xA0). Pylint's config file parser always reads rcfiles as utf-8, so that lone byte is an invalid start byte and raises UnicodeDecodeError on Windows only.

Fixes CI failures on win32:
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0