### PR TITLE
[REF] pre_commit_vauxoo: Move config files to subfolder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+.hypothesis/
 
 # Translations
 *.mo

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml.jinja
@@ -38,22 +38,22 @@ repos:
     hooks:
       - id: oca-checks-odoo-module
         args:
-          - --config=.oca_hooks-autofix.cfg
+          - --config=.hypothesis/.oca_hooks-autofix.cfg
           - --fix
       - id: oca-checks-odoo-module-fixit
         args:
-          - --config=.oca_hooks-autofix.cfg
+          - --config=.hypothesis/.oca_hooks-autofix.cfg
           - --fix
       - id: oca-checks-po
         args:
-          - --config=.oca_hooks-autofix.cfg
+          - --config=.hypothesis/.oca_hooks-autofix.cfg
           - --fix
 {%- else %}
     rev: v0.1.7
     hooks:
       - id: oca-checks-po
         args:
-          - --config=.oca_hooks-autofix.cfg
+          - --config=.hypothesis/.oca_hooks-autofix.cfg
           - --fix
 {%- endif %}
   - repo: https://github.com/psf/black-pre-commit-mirror.git
@@ -88,8 +88,7 @@ repos:
           - --write
           - --list-different
           - --ignore-unknown
-          # use this specific name because it is already listed in our .gitignore
-          - --config=.eslintrc_prettier.config.cjs
+          - --config=.hypothesis/.prettierrc.config.cjs
         types: [text]
         files: \.(js|xml)$
         language: node
@@ -140,5 +139,5 @@ repos:
         name: javascript lints autofix
         args:
           - --color
-          - --config=.eslintrc.config.mjs
+          - --config=.hypothesis/.eslintrc.config.mjs
           - --fix

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
@@ -37,7 +37,7 @@ repos:
       - id: pylint_odoo
         name: pylint optional checks
         args:
-          - --rcfile=.pylintrc-optional
+          - --rcfile=.hypothesis/.pylintrc-optional
           - --disable={{ pylint_disable_checks | join(",") if pylint_disable_checks else "R0000" }}
           # uncomment after fix https://github.com/OCA/pylint-odoo/pull/512
           # - --jobs=0  # 0 will auto-detect the number of processors available to use
@@ -55,6 +55,8 @@ repos:
     hooks:
       - id: doc8
         name: RST lint
+        args:
+          - --config=.hypothesis/doc8.ini
   - repo: local
     hooks:
       - id: vx-check-commit-log
@@ -79,7 +81,7 @@ repos:
         additional_dependencies: ["flake8-bugbear==23.9.16"]
 {%- endif %}
         args:
-          - --config=.flake8-optional
+          - --config=.hypothesis/.flake8-optional
   - repo: https://github.com/PyCQA/bandit
     rev: 1.9.2
     hooks:
@@ -88,7 +90,7 @@ repos:
         verbose: True
         args:
           - --exit-zero
-          - --ini=.bandit
+          - --ini=.hypothesis/.bandit
         # reduce the INFO logger
         require_serial: true
   - repo: https://github.com/OCA/pylint-odoo
@@ -102,5 +104,5 @@ repos:
         name: pylint EXPERIMENTAL checks (Won't affect CI status)!
         verbose: True  # exit-zero needs verbose
         args:
-          - --rcfile=.pylintrc-experimental
+          - --rcfile=.hypothesis/.pylintrc-experimental
           - --exit-zero

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml.jinja
@@ -36,6 +36,8 @@ repos:
     hooks:
       - id: flake8
         name: flake8 mandatory checks
+        args:
+          - --config=.hypothesis/.flake8
   - repo: https://github.com/OCA/pylint-odoo
 {%- if pylint_matrix_value >= 20 %}
     rev: v10.0.7
@@ -46,7 +48,7 @@ repos:
       - id: pylint_odoo
         name: pylint mandatory checks
         args:
-          - --rcfile=.pylintrc
+          - --rcfile=.hypothesis/.pylintrc
           - --disable={{ pylint_disable_checks | join(",") if pylint_disable_checks else "R0000" }}
           # uncomment after fix https://github.com/OCA/pylint-odoo/pull/512
           # - --jobs=0  # 0 will auto-detect the number of processors available to use
@@ -57,7 +59,7 @@ repos:
         name: javascript mandatory checks
         args:
           - --color
-          - --config=.eslintrc.config.mjs
+          - --config=.hypothesis/.eslintrc.config.mjs
   - repo: local
     hooks:
       - id: name-non-ascii

--- a/src/pre_commit_vauxoo/cfg/.prettierrc.config.cjs.jinja
+++ b/src/pre_commit_vauxoo/cfg/.prettierrc.config.cjs.jinja
@@ -1,7 +1,4 @@
 /** @type {import('prettier').Config} */
-// The ugly name of the file was to reduce the changes in the repos
-// since that it was already considered in our .gitignore
-// it is not related with eslint but prettier
 
 const config = {
   // https://github.com/prettier/prettier/issues/15388#issuecomment-1717746872

--- a/src/pre_commit_vauxoo/pre_commit_vauxoo.py
+++ b/src/pre_commit_vauxoo/pre_commit_vauxoo.py
@@ -22,6 +22,7 @@ re_export = re.compile(
     re.M,
 )
 
+CFG_SUBFOLDER = ".hypothesis"
 TOOLS_ORDER = (
     "prettier_matrix_value",
     "oca_hooks_matrix_value",
@@ -127,6 +128,17 @@ def copy_cfg_files(
     is_project_for_apps,
     compatibility_version,
 ):
+    """Copy configuration files from the package's cfg directory into a hidden
+    folder at the root of the repository.
+
+    This isolates the configuration files so they are not version-controlled in each
+    project repository, avoiding the need to update ``.gitignore`` for every new
+    tool.
+    """
+    # Destination directory inside the repository
+    cfg_dir = os.path.join(repo_dirname, CFG_SUBFOLDER)
+    os.makedirs(cfg_dir, exist_ok=True)
+
     exclude_lint_regex = ""
     exclude_autofix_regex = ""
     if exclude_lint:
@@ -141,7 +153,7 @@ def copy_cfg_files(
                 if exclude_path and exclude_path.strip()
             ]
         )
-    _logger.info("Copying configuration files 'cp -rnT %s/ %s/", precommit_config_dir, repo_dirname)
+    _logger.info("Copying configuration files 'cp -rnT %s/ %s/", precommit_config_dir, cfg_dir)
     if no_overwrite:
         # Use the custom files defined in the repo
         _logger.warning("Using custom files")
@@ -159,13 +171,25 @@ def copy_cfg_files(
     }
     copier.run_copy(
         src_path=precommit_config_dir,
-        dst_path=repo_dirname,
+        dst_path=cfg_dir,
         data=data,
         unsafe=True,
         defaults=True,
         overwrite=not no_overwrite,
         quiet=True,
     )
+
+    # .editorconfig must live at the repo root because prettier (and most
+    # editors) always search for it there with no CLI flag to override the
+    # path.  Move it out of the hidden subfolder after copier places it.
+    if os.path.isfile(editorconfig_src := os.path.join(cfg_dir, ".editorconfig")):
+        shutil.move(editorconfig_src, os.path.join(repo_dirname, ".editorconfig"))
+
+    # .isort.cfg must live at the repo root because the parameter config
+    # change the order of third-party packages
+    if os.path.isfile(isort_src := os.path.join(cfg_dir, ".isort.cfg")):
+        shutil.move(isort_src, os.path.join(repo_dirname, ".isort.cfg"))
+
     if exclude_autofix:
         _logger.info("Applying EXCLUDE_AUTOFIX=%s", exclude_autofix)
     if exclude_lint:
@@ -292,9 +316,11 @@ def main(
         return
     _logger.info("Installing pre-commit hooks")
     cmd = ["pre-commit", "install-hooks", "--color=always"]
-    pre_commit_cfg_mandatory = os.path.join(repo_dirname, ".pre-commit-config.yaml")
-    pre_commit_cfg_optional = os.path.join(repo_dirname, ".pre-commit-config-optional.yaml")
-    pre_commit_cfg_autofix = os.path.join(repo_dirname, ".pre-commit-config-autofix.yaml")
+    # Paths to the pre‑commit configuration files inside the hidden folder
+    cfg_dir = os.path.join(repo_dirname, ".hypothesis")
+    pre_commit_cfg_mandatory = os.path.join(cfg_dir, ".pre-commit-config.yaml")
+    pre_commit_cfg_optional = os.path.join(cfg_dir, ".pre-commit-config-optional.yaml")
+    pre_commit_cfg_autofix = os.path.join(cfg_dir, ".pre-commit-config-autofix.yaml")
     if "mandatory" in precommit_hooks_type:
         subprocess_call(cmd + ["-c", pre_commit_cfg_mandatory])
     if "optional" in precommit_hooks_type:
@@ -406,7 +432,7 @@ def main(
         _logger.info("*" * 68)
         _logger.info("%s OPTIONAL CHECKS %s", "~" * 25, "~" * 25)
         _logger.info("Running optional checks (does not affect status build)")
-        status_optional = subprocess_call(cmd + ["-c", os.path.join(repo_dirname, pre_commit_cfg_optional)])
+        status_optional = subprocess_call(cmd + ["-c", pre_commit_cfg_optional])
         test_name = "Optional checks"
         all_status[test_name] = {"status": status_optional}
         if status_optional and fail_optional:

--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -28,6 +28,7 @@ from pre_commit_vauxoo.hooks.check_commit_msg import (
     resolve_commit_message_base_ref,
     validate_commit_message_header,
 )
+from pre_commit_vauxoo.pre_commit_vauxoo import CFG_SUBFOLDER
 
 ANSI_ESCAPE_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 TEMPLATE_PATH = Path(__file__).resolve().parents[1] / "src" / "pre_commit_vauxoo" / "cfg"
@@ -127,7 +128,7 @@ class TestPreCommitVauxoo:
         os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"
         result = self.runner.invoke(main, [])
         assert not result.exit_code, "Exited with error %s - %s" % (result, result.output)
-        with open(os.path.join(self.tmp_dir, "pyproject.toml")) as f_pyproject:
+        with open(os.path.join(self.tmp_dir, CFG_SUBFOLDER, "pyproject.toml")) as f_pyproject:
             assert "skip-string-normalization=false" in f_pyproject.read(), "Skip string normalization not set"
 
     def test_chdir(self, caplog):
@@ -145,7 +146,7 @@ class TestPreCommitVauxoo:
         os.environ["EXCLUDE_LINT"] = "module_example1/models,module_warnings1/"
         result = self.runner.invoke(main, [])
         assert not result.exit_code, "Exited with error %s - %s" % (result, result.output)
-        with open(os.path.join(self.tmp_dir, "pyproject.toml")) as f_pyproject:
+        with open(os.path.join(self.tmp_dir, CFG_SUBFOLDER, "pyproject.toml")) as f_pyproject:
             f_content = f_pyproject.read()
         assert "skip-string-normalization=false" in f_content, "Skip string normalization not set"
 
@@ -153,7 +154,7 @@ class TestPreCommitVauxoo:
         os.environ["DISABLE_PYLINT_CHECKS"] = "import-error"
         result = self.runner.invoke(main, [])
         assert not result.exit_code, "Exited with error %s - %s" % (result, result.output)
-        with open(os.path.join(self.tmp_dir, ".pylintrc")) as f_pylintrc:
+        with open(os.path.join(self.tmp_dir, CFG_SUBFOLDER, ".pylintrc")) as f_pylintrc:
             f_content = f_pylintrc.read()
         assert "import-error," in f_content, "import-error was not disabled"
 
@@ -163,7 +164,7 @@ class TestPreCommitVauxoo:
         os.environ["BLACK_SKIP_STRING_NORMALIZATION"] = "true"
         result = self.runner.invoke(main, [])
         assert not result.exit_code, "Exited with error %s - %s" % (result, result.output)
-        with open(os.path.join(self.tmp_dir, "pyproject.toml")) as f_pyproject:
+        with open(os.path.join(self.tmp_dir, CFG_SUBFOLDER, "pyproject.toml")) as f_pyproject:
             assert "skip-string-normalization=true" in f_pyproject.read(), "Skip string normalization not set"
 
     def test_fail_warning(self, caplog):
@@ -386,9 +387,13 @@ class TestPreCommitVauxoo:
 
     def test_commit_msg_hook_is_in_optional_config(self):
         self.runner.invoke(main, ["--only-cp-cfg"])
-        with open(os.path.join(self.tmp_dir, ".pre-commit-config.yaml"), encoding="utf-8") as mandatory_cfg:
+        with open(
+            os.path.join(self.tmp_dir, CFG_SUBFOLDER, ".pre-commit-config.yaml"), encoding="utf-8"
+        ) as mandatory_cfg:
             mandatory_content = mandatory_cfg.read()
-        with open(os.path.join(self.tmp_dir, ".pre-commit-config-optional.yaml"), encoding="utf-8") as optional_cfg:
+        with open(
+            os.path.join(self.tmp_dir, CFG_SUBFOLDER, ".pre-commit-config-optional.yaml"), encoding="utf-8"
+        ) as optional_cfg:
             optional_content = optional_cfg.read()
 
         assert "vx-check-commit-msg" not in mandatory_content
@@ -425,7 +430,7 @@ class TestPreCommitVauxoo:
             manifest.write("{'installable': False}")
 
         self.runner.invoke(main, [])
-        with open(os.path.join(self.tmp_dir, ".pre-commit-config.yaml")) as config_fd:
+        with open(os.path.join(self.tmp_dir, CFG_SUBFOLDER, ".pre-commit-config.yaml")) as config_fd:
             config = load(config_fd, Loader)
 
         pattern = re.compile(config["exclude"])
@@ -437,8 +442,8 @@ class TestPreCommitVauxoo:
         os.environ["OCA_HOOKS_DISABLE_CHECKS"] = ",".join(expected_disabled)
         self.runner.invoke(main, [])
         oca_hooks_cfg_paths = [
-            Path(self.tmp_dir) / ".oca_hooks.cfg",
-            Path(self.tmp_dir) / ".oca_hooks-autofix.cfg",
+            Path(self.tmp_dir) / CFG_SUBFOLDER / ".oca_hooks.cfg",
+            Path(self.tmp_dir) / CFG_SUBFOLDER / ".oca_hooks-autofix.cfg",
         ]
         for oca_hooks_cfg_path in oca_hooks_cfg_paths:
             config = ConfigParser(inline_comment_prefixes=("#", ";"))
@@ -453,7 +458,8 @@ class TestPreCommitVauxoo:
         self.runner.invoke(main, ["--only-cp-cfg"])
         pylint_messages = self.get_pylint_messages()
         rc_files = [
-            os.path.abspath(os.path.join(self.tmp_dir, pylintrc)) for pylintrc in [".pylintrc", ".pylintrc-optional"]
+            os.path.abspath(os.path.join(self.tmp_dir, CFG_SUBFOLDER, pylintrc))
+            for pylintrc in [".pylintrc", ".pylintrc-optional"]
         ]
         for rc_file in rc_files:
             config = ConfigParser(inline_comment_prefixes=("#", ";"))
@@ -495,19 +501,19 @@ class TestPreCommitVauxoo:
     def test_apps_checks_disable(self, caplog):
         os.environ["PRECOMMIT_IS_PROJECT_FOR_APPS"] = "True"
         self.runner.invoke(main, [])
-        with open(os.path.join(self.tmp_dir, ".pylintrc")) as pylintrc:
+        with open(os.path.join(self.tmp_dir, CFG_SUBFOLDER, ".pylintrc")) as pylintrc:
             f_content = pylintrc.read()
         assert "category-allowed-app" not in f_content, "app check disabled for a project for apps"
 
         os.environ["PRECOMMIT_IS_PROJECT_FOR_APPS"] = "False"
         self.runner.invoke(main, [])
-        with open(os.path.join(self.tmp_dir, ".pylintrc")) as pylintrc:
+        with open(os.path.join(self.tmp_dir, CFG_SUBFOLDER, ".pylintrc")) as pylintrc:
             f_content = pylintrc.read()
         assert "category-allowed-app" in f_content, "app check enabled for a project for non apps"
 
         os.environ.pop("PRECOMMIT_IS_PROJECT_FOR_APPS")
         self.runner.invoke(main, [])
-        with open(os.path.join(self.tmp_dir, ".pylintrc")) as pylintrc:
+        with open(os.path.join(self.tmp_dir, CFG_SUBFOLDER, ".pylintrc")) as pylintrc:
             f_content = pylintrc.read()
         assert "category-allowed-app" in f_content, "app check enabled for a project for non apps (default value)"
 
@@ -527,7 +533,7 @@ class TestPreCommitVauxoo:
         }
         for pylintrc, expected_modules in expected_by_file.items():
             config = ConfigParser(inline_comment_prefixes=("#", ";"))
-            config.read(os.path.join(self.tmp_dir, pylintrc))
+            config.read(os.path.join(self.tmp_dir, CFG_SUBFOLDER, pylintrc))
             deprecated_modules = {
                 item.strip()
                 for item in config.get("IMPORTS", "deprecated-modules").replace("\n", "").split(",")
@@ -536,7 +542,7 @@ class TestPreCommitVauxoo:
             assert expected_modules.issubset(deprecated_modules)
 
         config = ConfigParser(inline_comment_prefixes=("#", ";"))
-        config.read(os.path.join(self.tmp_dir, ".pylintrc"))
+        config.read(os.path.join(self.tmp_dir, CFG_SUBFOLDER, ".pylintrc"))
         enabled = {
             item.strip() for item in config["MESSAGES CONTROL"]["disable"].replace("\n", "").split(",") if item.strip()
         }


### PR DESCRIPTION
Previously all lint/format configuration files
(.pylintrc, .flake8, .bandit, .eslintrc*, .pre-commit-config*.yaml, ...) were copied directly into the root of each consumer repository. This forced every project to keep its .gitignore updated whenever a new config file was added or renamed by this package, causing drift and manual maintenance across many repos.

This commit centralizes all generated configuration files into a single hidden subfolder, at the repo root:

- `copy_cfg_files` now copies files into `<repo>/.subfolder/` instead of `<repo>/`, so a project only needs to ignore one folder.
- `.editorconfig` is still moved back to the repo root after the copy, since prettier and most editors only look for it there and have no CLI flag to override its location.
- All `--config`/`--rcfile`/`--ini`/`--sp` args in the mandatory, optional and autofix pre-commit hook definitions were updated to point to `.subfoder/<file>`.
- `pre-commit install-hooks` and the mandatory/optional/autofix run commands now resolve the `.pre-commit-config*.yaml` files from `.subfoder/` as well.
- Tests updated to read generated config files from `<tmp_dir>/.subfoder/` via the new `CFG_SUBFOLDER` constant.

This removes the need to touch each project's .gitignore for new tooling files going forward.

The subfolder `.hypothesis` was used because it is already present in the `.gitignore` file of all our projects and in the base template, so no extra changes are needed in existing repos to start ignoring it. In the future this may be renamed to `.configuration` or `.config`, but that will depend on updating the .gitignore across all projects first.