### PR TITLE
[IMP] markdownlint: Add markdown autofixes rules

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.markdownlint-autofix.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.markdownlint-autofix.yaml.jinja
@@ -1,0 +1,73 @@
+# Disable all checks without autofixes
+
+# MD001 heading-increment
+MD001: false
+
+# MD002 first-heading-h1
+MD002: false
+
+# MD003 heading-style
+MD003: false
+
+# MD006 ul-start-left
+MD006: false
+
+# MD013 line-length
+MD013: false
+
+# MD016 no-multiple-space-atx
+MD016: false
+
+# MD024 no-duplicate-heading
+MD024: false
+
+# MD025 single-title / single-h1
+MD025: false
+
+# MD028 no-blanks-blockquote
+MD028: false
+
+# MD033 no-inline-html
+MD033: false
+
+# MD036 no-emphasis-as-heading
+MD036: false
+
+# MD040 fenced-code-language
+MD040: false
+
+# MD041 first-line-heading
+MD041: false
+
+# MD042 no-empty-links
+MD042: false
+
+# MD043 required-headings
+MD043: false
+
+# MD045 no-alt-text
+MD045: false
+
+# MD046 code-block-style
+MD046: false
+
+# MD048 code-fence-style
+MD048: false
+
+# MD052 reference-redefinitions
+MD052: false
+
+# MD055 table-pipe-style
+MD055: false
+
+# MD056 table-column-count
+MD056: false
+
+# MD057 sub-heading-indent
+MD057: false
+
+# MD059 descriptive-link-text
+MD059: false
+
+# MD060 table-column-style
+MD060: false

--- a/src/pre_commit_vauxoo/cfg/{% if use_ruff %}.pre-commit-config-autofix.yaml{% endif %}.jinja
+++ b/src/pre_commit_vauxoo/cfg/{% if use_ruff %}.pre-commit-config-autofix.yaml{% endif %}.jinja
@@ -29,7 +29,7 @@ exclude: |
   )
 default_language_version:
   python: python3
-  node: "24.13.0"
+  node: "26.5.0"
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.0
@@ -92,7 +92,7 @@ repos:
       - id: remove-tabs
         exclude: (Makefile|debian/rules|.gitmodules|\.po|\.pot)(\.in)?$
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.39.1
+    rev: v10.8.0
     hooks:
       - id: eslint
         name: javascript lints autofix
@@ -100,3 +100,11 @@ repos:
           - --color
           - --config=.config/.eslintrc.config.mjs
           - --fix
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.49.1
+    hooks:
+    - id: markdownlint
+      verbose: True
+      args:
+        - --config=.config/.markdownlint-autofix.yaml
+        - --fix


### PR DESCRIPTION
Add markdownlint with rules that can be automatically fixed

This reduces manual friction during the
pre-commit-vauxoo phase, ensuring the  linter only
enforces formatting that it can resolve automatically

Inspired from https://github.com/Vauxoo/pre-commit-vauxoo/pull/237 thanks to @hugho-ad 