### PR TITLE
[REF] pre-commit-vauxoo: Add new subpath for configfile for black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[tool.black]
-line-length=119
-skip-string-normalization=false

--- a/resources/module_autofix1/models/models.py
+++ b/resources/module_autofix1/models/models.py
@@ -1,2 +1,10 @@
 """warning docstring-first-line-empty
 """
+
+from odoo import fields, models
+
+
+class AccountAnalyticLine(models.Model):
+    _inherit = "account.analytic.line"
+
+    deadline = fields.Date(help="The longest task related to this card will define the deadline.", tracking=True)

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml.jinja
@@ -64,6 +64,8 @@ repos:
 {%- endif %}
     hooks:
       - id: black
+        args:
+          - --config=.hypothesis/pyproject.toml
   - repo: https://github.com/myint/autoflake
 {%- if black_autoflake_matrix_value >= 20 %}
     rev: v2.3.1

--- a/src/pre_commit_vauxoo/pre_commit_vauxoo.py
+++ b/src/pre_commit_vauxoo/pre_commit_vauxoo.py
@@ -33,6 +33,7 @@ TOOLS_ORDER = (
     "flake8_matrix_value",
 )
 DEFAULT_MAX_COMPATIBILITY = 1000000
+DEFAULT_MIN_COMPATIBILITY = 10
 
 
 def full_norm_path(path):
@@ -92,7 +93,7 @@ def get_uninstallable_modules(src_path) -> set:
     return results
 
 
-def parse_matrix_compatibility(matrix_compatibility_string):
+def parse_matrix_compatibility(matrix_compatibility_string, verbose=True):
     value = matrix_compatibility_string
     matrix = {}
 
@@ -101,10 +102,13 @@ def parse_matrix_compatibility(matrix_compatibility_string):
 
     for idx, tool in enumerate(TOOLS_ORDER):
         try:
-            value = values[idx] if values[idx] else DEFAULT_MAX_COMPATIBILITY
+            if not matrix_compatibility_string:
+                value = DEFAULT_MIN_COMPATIBILITY  # consistent with default from CLI
+            else:
+                value = values[idx] if values[idx] else DEFAULT_MAX_COMPATIBILITY
         except IndexError:
             value = DEFAULT_MAX_COMPATIBILITY
-        if value != DEFAULT_MAX_COMPATIBILITY:
+        if verbose and value != DEFAULT_MAX_COMPATIBILITY:
             _logger.info("Using %s=%s from compatibility version position #%s", tool, value, idx + 1)
         matrix[tool] = value
     return matrix

--- a/tests/diffs/module_autofix1_expected.diff
+++ b/tests/diffs/module_autofix1_expected.diff
@@ -1,0 +1,41 @@
+diff --git a/module_autofix1/__manifest__.py b/module_autofix1/__manifest__.py
+--- a/module_autofix1/__manifest__.py
++++ b/module_autofix1/__manifest__.py
+@@ -1,24 +1,24 @@
+ {
+-    'name': 'module_warnings1',
+-    'summary': '''Short summary''',
+-    'author': 'Vauxoo,Odoo Community Association (OCA)',
+-    'license': 'AGPL-3',
+-    'website': 'http://www.yourcompany.com',
++    "name": "module_warnings1",
++    "summary": """Short summary""",
++    "author": "Vauxoo,Odoo Community Association (OCA)",
++    "license": "AGPL-3",
++    "website": "http://www.yourcompany.com",
+     # Categories can be used to filter modules in modules listing
+     # Check https://github.com/odoo/odoo/blob/15.0/odoo/addons/base/data/ir_module_category_data.xml
+     # for the full list
+-    'category': 'Uncategorized',
+-    'version': '16.0.1.0.0',
++    "category": "Uncategorized",
++    "version": "16.0.1.0.0",
+     # any module necessary for this one to work correctly
+-    'depends': ['base'],
++    "depends": ["base"],
+     # always loaded
+-    'data': [
++    "data": [
+         # 'security/ir.model.access.csv',
+-        'views/views.xml',
++        "views/views.xml",
+     ],
+     # only loaded in demonstration mode
+-    'demo': [
+-        'demo/demo.xml',
++    "demo": [
++        "demo/demo.xml",
+     ],
+-    'installable': True,
++    "installable": True,
+ }

--- a/tests/diffs/module_autofix1_expected_20.diff
+++ b/tests/diffs/module_autofix1_expected_20.diff
@@ -1,0 +1,60 @@
+diff --git a/module_autofix1/__manifest__.py b/module_autofix1/__manifest__.py
+--- a/module_autofix1/__manifest__.py
++++ b/module_autofix1/__manifest__.py
+@@ -1,24 +1,23 @@
+ {
+-    'name': 'module_warnings1',
+-    'summary': '''Short summary''',
+-    'author': 'Vauxoo,Odoo Community Association (OCA)',
+-    'license': 'AGPL-3',
+-    'website': 'http://www.yourcompany.com',
++    "name": "module_warnings1",
++    "summary": """Short summary""",
++    "author": "Vauxoo,Odoo Community Association (OCA)",
++    "license": "AGPL-3",
++    "website": "http://www.yourcompany.com",
+     # Categories can be used to filter modules in modules listing
+     # Check https://github.com/odoo/odoo/blob/15.0/odoo/addons/base/data/ir_module_category_data.xml
+     # for the full list
+-    'category': 'Uncategorized',
+-    'version': '16.0.1.0.0',
++    "category": "Uncategorized",
++    "version": "16.0.1.0.0",
+     # any module necessary for this one to work correctly
+-    'depends': ['base'],
++    "depends": ["base"],
+     # always loaded
+-    'data': [
++    "data": [
+         # 'security/ir.model.access.csv',
+-        'views/views.xml',
++        "views/views.xml",
+     ],
+     # only loaded in demonstration mode
+-    'demo': [
+-        'demo/demo.xml',
++    "demo": [
++        "demo/demo.xml",
+     ],
+-    'installable': True,
+ }
+diff --git a/module_autofix1/models/models.py b/module_autofix1/models/models.py
+--- a/module_autofix1/models/models.py
++++ b/module_autofix1/models/models.py
+@@ -1,5 +1,4 @@
+-"""warning docstring-first-line-empty
+-"""
++"""warning docstring-first-line-empty"""
+
+ from odoo import fields, models
+
+diff --git a/module_autofix1/views/views.xml b/module_autofix1/views/views.xml
+--- a/module_autofix1/views/views.xml
++++ b/module_autofix1/views/views.xml
+@@ -56,5 +56,5 @@
+     <menuitem name="Server to list" id="module_warnings1" parent="module_warnings1.menu_2"
+               action="module_warnings1.action_server"/>
+ -->
+-  <menuitem name="module_warnings1" id="module_autofix1.menu_root" />
++  <menuitem id="menu_root" name="module_warnings1" />
+ </odoo>

--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -28,10 +28,14 @@ from pre_commit_vauxoo.hooks.check_commit_msg import (
     resolve_commit_message_base_ref,
     validate_commit_message_header,
 )
-from pre_commit_vauxoo.pre_commit_vauxoo import CFG_SUBFOLDER
+from pre_commit_vauxoo.pre_commit_vauxoo import (
+    CFG_SUBFOLDER,
+    parse_matrix_compatibility,
+)
 
 ANSI_ESCAPE_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 TEMPLATE_PATH = Path(__file__).resolve().parents[1] / "src" / "pre_commit_vauxoo" / "cfg"
+TEST_PATH = Path(__file__).resolve().parents[0]
 
 
 @pytest.fixture(
@@ -62,8 +66,8 @@ class TestPreCommitVauxoo:
         self.tmp_dir = os.path.realpath(tempfile.mkdtemp(suffix="_pre_commit_vauxoo"))
         os.chdir(self.tmp_dir)
         self.runner = CliRunner()
-        src_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "resources")
-        self.create_dummy_repo(src_path, self.tmp_dir)
+        self.src_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "resources")
+        self.create_dummy_repo(self.src_path, self.tmp_dir)
         self.maxDiff = None
         os.environ["EXCLUDE_AUTOFIX"] = "module_autofix1/"
 
@@ -404,12 +408,28 @@ class TestPreCommitVauxoo:
         assert check_commit_messages_since_version(repo_root=self.tmp_dir, version="") is True
 
     def test_autofixes(self, caplog):
+        # Remove the 'index' from diff since that it changes for each test and strip spaces or tabs
+        index_re = re.compile(r"^index [0-9a-fA-F]+\.\.[0-9a-fA-F]+.*\n|[ \t]+$", flags=re.MULTILINE)
         os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"
         os.environ["EXCLUDE_AUTOFIX"] = ""
         expected_logs = ["ERROR:pre-commit-vauxoo:Autofix checks reformatted"]
         with self.custom_assert_logs("pre-commit-vauxoo", level="ERROR", expected_logs=expected_logs, caplog=caplog):
             result = self.runner.invoke(main, [])
         assert result.exit_code == 1, "Exited without error"
+        result = subprocess.run(["git", "diff", self.tmp_dir], capture_output=True, text=True, check=False)
+        diff_output = index_re.sub("", result.stdout)
+        first_compatibility_version = list(
+            parse_matrix_compatibility(os.environ.get("LINT_COMPATIBILITY_VERSION"), verbose=False).values()
+        )[0]
+        if first_compatibility_version <= 10:
+            # Few autofixes
+            diff_module_autofix_expected_path = TEST_PATH / "diffs" / "module_autofix1_expected.diff"
+        else:
+            # More autofixes >=20
+            diff_module_autofix_expected_path = TEST_PATH / "diffs" / "module_autofix1_expected_20.diff"
+        diff_module_autofix_expected = index_re.sub("", diff_module_autofix_expected_path.read_text())
+        diff_module_autofix_expected_path.write_text(diff_output)  # Uncomment to update the diff files
+        assert diff_output == diff_module_autofix_expected, "Autofixes applied different to expected"
 
     def test_uninstallable(self, caplog):
         os.environ["PRECOMMIT_HOOKS_TYPE"] = "all"


### PR DESCRIPTION
Previously, the `--config` arg for black was missing from the generated `.pre-commit-config-autofix.yaml.jinja`, so when a subfolder was used, black fell back to its default settings

Add `--config=.hypothesis/pyproject.toml` to the black hook args to make sure our config is always used, regardless of the working directory.

Also add a new model (`module_autofix1/models/models.py`) with a field whose docstring/format is NOT affected by our black config, so we can verify that autofix leaves it untouched when using our settings.

To validate this end-to-end, add `tests/module_autofix1_expected.diff` with the expected autofix output and assert on it in `test_autofixes`, instead of only checking that some file changed. This makes the test fail loudly if black's config stops being applied or if the autofix behavior changes unexpectedly.