### PR TITLE
[REF] pre_commit_vauxoo: Use `.config` instead of `.hypothesis` as CFG_SUBFOLDER

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-autofix.yaml.jinja
@@ -38,22 +38,22 @@ repos:
     hooks:
       - id: oca-checks-odoo-module
         args:
-          - --config=.hypothesis/.oca_hooks-autofix.cfg
+          - --config=.config/.oca_hooks-autofix.cfg
           - --fix
       - id: oca-checks-odoo-module-fixit
         args:
-          - --config=.hypothesis/.oca_hooks-autofix.cfg
+          - --config=.config/.oca_hooks-autofix.cfg
           - --fix
       - id: oca-checks-po
         args:
-          - --config=.hypothesis/.oca_hooks-autofix.cfg
+          - --config=.config/.oca_hooks-autofix.cfg
           - --fix
 {%- else %}
     rev: v0.1.7
     hooks:
       - id: oca-checks-po
         args:
-          - --config=.hypothesis/.oca_hooks-autofix.cfg
+          - --config=.config/.oca_hooks-autofix.cfg
           - --fix
 {%- endif %}
   - repo: https://github.com/psf/black-pre-commit-mirror.git
@@ -65,7 +65,7 @@ repos:
     hooks:
       - id: black
         args:
-          - --config=.hypothesis/pyproject.toml
+          - --config=.config/pyproject.toml
   - repo: https://github.com/myint/autoflake
 {%- if black_autoflake_matrix_value >= 20 %}
     rev: v2.3.1
@@ -90,7 +90,7 @@ repos:
           - --write
           - --list-different
           - --ignore-unknown
-          - --config=.hypothesis/.prettierrc.config.cjs
+          - --config=.config/.prettierrc.config.cjs
         types: [text]
         files: \.(js|xml)$
         language: node
@@ -141,5 +141,5 @@ repos:
         name: javascript lints autofix
         args:
           - --color
-          - --config=.hypothesis/.eslintrc.config.mjs
+          - --config=.config/.eslintrc.config.mjs
           - --fix

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
@@ -37,7 +37,7 @@ repos:
       - id: pylint_odoo
         name: pylint optional checks
         args:
-          - --rcfile=.hypothesis/.pylintrc-optional
+          - --rcfile=.config/.pylintrc-optional
           - --disable={{ pylint_disable_checks | join(",") if pylint_disable_checks else "R0000" }}
           # uncomment after fix https://github.com/OCA/pylint-odoo/pull/512
           # - --jobs=0  # 0 will auto-detect the number of processors available to use
@@ -56,7 +56,7 @@ repos:
       - id: doc8
         name: RST lint
         args:
-          - --config=.hypothesis/doc8.ini
+          - --config=.config/doc8.ini
   - repo: local
     hooks:
       - id: vx-check-commit-log
@@ -81,7 +81,7 @@ repos:
         additional_dependencies: ["flake8-bugbear==23.9.16"]
 {%- endif %}
         args:
-          - --config=.hypothesis/.flake8-optional
+          - --config=.config/.flake8-optional
   - repo: https://github.com/PyCQA/bandit
     rev: 1.9.2
     hooks:
@@ -90,7 +90,7 @@ repos:
         verbose: True
         args:
           - --exit-zero
-          - --ini=.hypothesis/.bandit
+          - --ini=.config/.bandit
         # reduce the INFO logger
         require_serial: true
   - repo: https://github.com/OCA/pylint-odoo
@@ -104,5 +104,5 @@ repos:
         name: pylint EXPERIMENTAL checks (Won't affect CI status)!
         verbose: True  # exit-zero needs verbose
         args:
-          - --rcfile=.hypothesis/.pylintrc-experimental
+          - --rcfile=.config/.pylintrc-experimental
           - --exit-zero

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml.jinja
@@ -37,7 +37,7 @@ repos:
       - id: flake8
         name: flake8 mandatory checks
         args:
-          - --config=.hypothesis/.flake8
+          - --config=.config/.flake8
   - repo: https://github.com/OCA/pylint-odoo
 {%- if pylint_matrix_value >= 20 %}
     rev: v10.0.7
@@ -48,7 +48,7 @@ repos:
       - id: pylint_odoo
         name: pylint mandatory checks
         args:
-          - --rcfile=.hypothesis/.pylintrc
+          - --rcfile=.config/.pylintrc
           - --disable={{ pylint_disable_checks | join(",") if pylint_disable_checks else "R0000" }}
           # uncomment after fix https://github.com/OCA/pylint-odoo/pull/512
           # - --jobs=0  # 0 will auto-detect the number of processors available to use
@@ -59,7 +59,7 @@ repos:
         name: javascript mandatory checks
         args:
           - --color
-          - --config=.hypothesis/.eslintrc.config.mjs
+          - --config=.config/.eslintrc.config.mjs
   - repo: local
     hooks:
       - id: name-non-ascii

--- a/src/pre_commit_vauxoo/pre_commit_vauxoo.py
+++ b/src/pre_commit_vauxoo/pre_commit_vauxoo.py
@@ -22,7 +22,7 @@ re_export = re.compile(
     re.M,
 )
 
-CFG_SUBFOLDER = ".hypothesis"
+CFG_SUBFOLDER = ".config"
 TOOLS_ORDER = (
     "prettier_matrix_value",
     "oca_hooks_matrix_value",
@@ -321,7 +321,7 @@ def main(
     _logger.info("Installing pre-commit hooks")
     cmd = ["pre-commit", "install-hooks", "--color=always"]
     # Paths to the pre‑commit configuration files inside the hidden folder
-    cfg_dir = os.path.join(repo_dirname, ".hypothesis")
+    cfg_dir = os.path.join(repo_dirname, CFG_SUBFOLDER)
     pre_commit_cfg_mandatory = os.path.join(cfg_dir, ".pre-commit-config.yaml")
     pre_commit_cfg_optional = os.path.join(cfg_dir, ".pre-commit-config-optional.yaml")
     pre_commit_cfg_autofix = os.path.join(cfg_dir, ".pre-commit-config-autofix.yaml")


### PR DESCRIPTION
The `.config` sub-folder was already present and is a cleaner, less arbitrary name than `.hypothesis` for storing the pre-commit configuration files.

Also replace the hardcoded `.hypothesis` path in the cfg_dir assignment with the CFG_SUBFOLDER constant to avoid duplication and keep a single source of truth.