### PR TITLE
[REF] pre-commit-config*: Update pylint version

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
@@ -29,7 +29,7 @@ default_language_version:
 repos:
   - repo: https://github.com/OCA/pylint-odoo
 {%- if pylint_matrix_value >= 20 %}
-    rev: v10.0.7
+    rev: v10.0.8
 {%- else %}
     rev: v9.3.24
 {%- endif %}
@@ -95,7 +95,7 @@ repos:
         require_serial: true
   - repo: https://github.com/OCA/pylint-odoo
 {%- if pylint_matrix_value >= 20 %}
-    rev: v10.0.7
+    rev: v10.0.8
 {%- else %}
     rev: v9.3.24
 {%- endif %}

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config.yaml.jinja
@@ -40,7 +40,7 @@ repos:
           - --config=.config/.flake8
   - repo: https://github.com/OCA/pylint-odoo
 {%- if pylint_matrix_value >= 20 %}
-    rev: v10.0.7
+    rev: v10.0.8
 {%- else %}
     rev: v9.3.24
 {%- endif %}


### PR DESCRIPTION
Only for pylint_matrix_value >= 20 since that new projects should be it enabled

and new check added is only for Odoo 19.0+

Check the following output:
 - 
<img width="1239" height="452" alt="Screenshot 2026-07-18 at 12 34 29 a m" src="https://github.com/user-attachments/assets/8d4cb343-20ed-4142-8a0e-08e1fb181c79" />


