### PR TITLE
[REF] pre-commit-config-optional: Moved Bandit B704 markupsafe_markup_xss to optional

### DIFF
--- a/src/pre_commit_vauxoo/cfg/.bandit-experimental
+++ b/src/pre_commit_vauxoo/cfg/.bandit-experimental
@@ -2,9 +2,10 @@
 exclude = tests
 
 # B608: hardcoded_sql_expressions they are considered from pylint-odoo
-# B313,B314,B315,B316,B317,B318,B319,B320,B405,B406,B407,B408,B409,B410: defusedxml checks
+# B313,B314,B315,B316,B317,B318,B319,B405,B406,B407,B408,B409: defusedxml checks
 #   Odoo's team via inbox twitter is not convinced to repair them and the entire Odoo is raising these checks
-skips = B608,B313,B314,B315,B316,B317,B318,B319,B320,B405,B406,B407,B408,B409,B410
+# B704: It is already enabled from .bandit-optional
+skips = B608,B313,B314,B315,B316,B317,B318,B319,B405,B406,B407,B408,B409,B704
 format = custom
 msg-template={relpath}:{line}:{col} {msg} - [{test_id}] - ({severity})
 quiet=True

--- a/src/pre_commit_vauxoo/cfg/.bandit-optional
+++ b/src/pre_commit_vauxoo/cfg/.bandit-optional
@@ -1,0 +1,8 @@
+[bandit]
+exclude = tests
+
+# B704:markupsafe_markup_xss more info https://github.com/OCA/pylint-odoo/pull/578
+tests = B704
+format = custom
+msg-template={relpath}:{line}:{col} {msg} - [{test_id}] - ({severity})
+quiet=True

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
@@ -83,14 +83,24 @@ repos:
         args:
           - --config=.config/.flake8-optional
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.9.2
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        name: bandit optional
+        verbose: True
+        args:
+          - --ini=.config/.bandit-optional
+        # reduce the INFO logger
+        require_serial: true
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
     hooks:
       - id: bandit
         name: bandit EXPERIMENTAL (Won't affect CI status)!
         verbose: True
         args:
           - --exit-zero
-          - --ini=.config/.bandit
+          - --ini=.config/.bandit-experimental
         # reduce the INFO logger
         require_serial: true
   - repo: https://github.com/OCA/pylint-odoo


### PR DESCRIPTION
More info about enabling markupsafe_markup_xss
 - https://github.com/OCA/pylint-odoo/pull/578

- Rename `.bandit` to `.bandit-experimental` to better reflect its nature.
- Add `.bandit-optional` config to exclusively test rule B704 (markupsafe_markup_xss).
  - https://bandit.readthedocs.io/en/latest/plugins/b704_markupsafe_markup_xss.html
- Skip B704 in the experimental config to avoid duplicate checks.
- Update Bandit hooks in pre-commit config from 1.9.2 to 1.9.4.
- Remove B320 and B410 from skips in experimental config.
  - Fix `WARNING Unknown test found in profile``

Kudos Randall from https://git.vauxoo.com/vauxoo/spc/-/merge_requests/271