### PR TITLE
[IMP] bandit-optional: Allow html_sanitize calls for markupsafe B704

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,9 @@ source = src
 source = src
 parallel = true
 context = ${{COVERAGE_CONTEXT}}
+# "sysmon" is the default core since python3.14 but it does not support the dynamic
+# contexts set by "pytest --cov-context=test" raising a CoverageWarning for each test
+core = ctrace
 
 [report]
 show_missing = true

--- a/resources/module_example1/models/__init__.py
+++ b/resources/module_example1/models/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import markupsafe_sanitized

--- a/resources/module_example1/models/markupsafe_sanitized.py
+++ b/resources/module_example1/models/markupsafe_sanitized.py
@@ -1,0 +1,12 @@
+from markupsafe import Markup
+
+from odoo.tools import html_sanitize
+
+
+def body2markup(body):
+    """Build a HTML body for 'message_post' without raising bandit B704
+
+    Markup() is mandatory since 'message_post' escapes anything that is not a
+    Markup object, so the value is sanitized instead of escaped
+    """
+    return Markup(html_sanitize(body))

--- a/src/pre_commit_vauxoo/cfg/.bandit-experimental.yml
+++ b/src/pre_commit_vauxoo/cfg/.bandit-experimental.yml
@@ -1,11 +1,22 @@
-[bandit]
-exclude = tests
+exclude_dirs:
+  - tests
 
 # B608: hardcoded_sql_expressions they are considered from pylint-odoo
 # B313,B314,B315,B316,B317,B318,B319,B405,B406,B407,B408,B409: defusedxml checks
 #   Odoo's team via inbox twitter is not convinced to repair them and the entire Odoo is raising these checks
-# B704: It is already enabled from .bandit-optional
-skips = B608,B313,B314,B315,B316,B317,B318,B319,B405,B406,B407,B408,B409,B704
-format = custom
-msg-template={relpath}:{line}:{col} {msg} - [{test_id}] - ({severity})
-quiet=True
+# B704: It is already enabled from .bandit-optional.yml
+skips:
+  - B608
+  - B313
+  - B314
+  - B315
+  - B316
+  - B317
+  - B318
+  - B319
+  - B405
+  - B406
+  - B407
+  - B408
+  - B409
+  - B704

--- a/src/pre_commit_vauxoo/cfg/.bandit-optional
+++ b/src/pre_commit_vauxoo/cfg/.bandit-optional
@@ -1,8 +1,0 @@
-[bandit]
-exclude = tests
-
-# B704:markupsafe_markup_xss more info https://github.com/OCA/pylint-odoo/pull/578
-tests = B704
-format = custom
-msg-template={relpath}:{line}:{col} {msg} - [{test_id}] - ({severity})
-quiet=True

--- a/src/pre_commit_vauxoo/cfg/.bandit-optional.yml
+++ b/src/pre_commit_vauxoo/cfg/.bandit-optional.yml
@@ -1,0 +1,15 @@
+exclude_dirs:
+  - tests
+
+# B704:markupsafe_markup_xss more info https://github.com/OCA/pylint-odoo/pull/578
+tests:
+  - B704
+
+# Markup() is required to post HTML in Odoo (mail_thread.message_post() runs
+# escape(body) and keeps it as is only for Markup objects), so the value can not
+# simply be escaped. Wrapping the value with html_sanitize() is the safe way to
+# build it, so it is whitelisted instead of forcing "# nosec" comments.
+markupsafe_xss:
+  allowed_calls:
+    - odoo.tools.html_sanitize
+    - odoo.tools.mail.html_sanitize

--- a/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
+++ b/src/pre_commit_vauxoo/cfg/.pre-commit-config-optional.yaml.jinja
@@ -89,7 +89,12 @@ repos:
         name: bandit optional
         verbose: True
         args:
-          - --ini=.config/.bandit-optional
+          # The YAML format is used instead of the INI one since it is the only
+          # one supporting per-plugin options, e.g. "markupsafe_xss"
+          - --configfile=.config/.bandit-optional.yml
+          - --format=custom
+          - "--msg-template={relpath}:{line}:{col} {msg} - [{test_id}] - ({severity})"
+          - --quiet
         # reduce the INFO logger
         require_serial: true
   - repo: https://github.com/PyCQA/bandit
@@ -100,7 +105,10 @@ repos:
         verbose: True
         args:
           - --exit-zero
-          - --ini=.config/.bandit-experimental
+          - --configfile=.config/.bandit-experimental.yml
+          - --format=custom
+          - "--msg-template={relpath}:{line}:{col} {msg} - [{test_id}] - ({severity})"
+          - --quiet
         # reduce the INFO logger
         require_serial: true
   - repo: https://github.com/OCA/pylint-odoo

--- a/tests/test_pre_commit_vauxoo.py
+++ b/tests/test_pre_commit_vauxoo.py
@@ -168,7 +168,7 @@ class TestPreCommitVauxoo:
         with Path(os.path.join(self.tmp_dir, CFG_SUBFOLDER, "pyproject.toml")).open() as f_pyproject:
             assert "skip-string-normalization=true" in f_pyproject.read(), "Skip string normalization not set"
 
-    def test_fail_warning(self, caplog):
+    def test_fail_warning(self, caplog, capfd):
         os.environ["PRECOMMIT_FAIL_OPTIONAL"] = "1"
         # Only optional
         os.environ["PRECOMMIT_HOOKS_TYPE"] = "optional"
@@ -176,6 +176,12 @@ class TestPreCommitVauxoo:
         with self.custom_assert_logs("pre-commit-vauxoo", level="ERROR", expected_logs=expected_logs, caplog=caplog):
             result = self.runner.invoke(main, [])
         assert result.exit_code == 1, "Exited without error"
+        output = self.strip_ansi(capfd.readouterr().out)
+        # "resources/module_example1/models/markupsafe_sanitized.py" sanitizes the value
+        # so B704:markupsafe_markup_xss must not be raised for it, it is defined
+        # from the "allowed_calls" of the ".bandit-optional.yml" configuration file
+        bandit_passed = re.search(r"^bandit optional\.+Passed$", output, re.MULTILINE)
+        assert bandit_passed, "bandit optional did not pass\n%s" % output
 
     def test_rm_options(self, caplog):
         # Only mandatory


### PR DESCRIPTION
Markup() is mandatory to post HTML in Odoo since 'message_post' escapes anything that is not a Markup object, so B704 can not be fixed escaping the value but sanitizing it with html_sanitize()

The bandit INI format does not support per-plugin options so the allowed calls are defined in a new YAML file referenced using 'configfile'